### PR TITLE
Bump version to 0.5.10 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "0.5.9"
+version = "0.5.10"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
This pull request includes a minor version bump for the `tachyon-api` package. The version has been updated from `0.5.9` to `0.5.10` in the `pyproject.toml` file.