### PR TITLE
perf(F8): TachyonScope — eliminate Starlette Request from hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+**F8 — Eliminate Request object from hot path** (`feature/no-request`)
+
+- New `processing/scope.py` + `processing/scope.pyx`: `TachyonScope` — thin ASGI scope
+  wrapper with `__slots__`, direct C-field None checks (Cython `cdef class`), and no
+  Starlette class hierarchy. Implements the exact subset of the Request API that
+  `process_parameters` uses: `path_params`, `query_params`, `headers`, `cookies`,
+  `body()`, `form()`.
+- `app.py`: `_trie_dispatch` creates `TachyonScope(scope, receive, send)` instead of
+  `Request(scope, receive, send)` for parameterised endpoints.
+- `KIND_REQUEST` params: `as_request()` materialises the full Starlette `Request`
+  lazily — only when the endpoint explicitly declares `request: Request`.
+- Exception handlers: `request.as_request()` called on error paths only — no overhead
+  on the happy path.
+- `processing/dependencies.py`: `resolve_callable_dependency` calls `as_request()` when
+  injecting `Request` into callable dependencies.
+- `setup.py`: `scope.pyx` added to the Cython extension build.
+- Micro-benchmark delta: `TachyonScope()` **221ns** vs `Request()` **398ns** → **−176ns/req**
+  on all parameterised endpoints. Exceeds the F8 roadmap target of −100ns.
+
 **F7 — Direct dispatch — list args, no kwargs dict** (`feature/direct-dispatch`)
 
 - `processing/parameters.py` + `parameters.pyx`: `process_parameters` now returns a

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,11 @@ try:
             sources=["tachyon_api/processing/response_processor.pyx"],
             extra_compile_args=extra_compile_args,
         ),
+        Extension(
+            "tachyon_api.processing.scope",
+            sources=["tachyon_api/processing/scope.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
     ]
 
     setup(

--- a/tachyon_api/app.py
+++ b/tachyon_api/app.py
@@ -31,6 +31,7 @@ from .processing.compiler import compile_endpoint
 from .processing.parameters import ParameterProcessor
 from .processing.dependencies import DependencyResolver
 from .processing.response_processor import ResponseProcessor
+from .processing.scope import TachyonScope
 from .routing.trie import RadixTrie, _NOT_FOUND, _METHOD_NOT_ALLOWED, _FOUND
 
 try:
@@ -219,7 +220,9 @@ class Tachyon:
             # Phase 5b fast-path: no-param endpoints skip Request() creation
             await handler.fn(scope, receive, send)
         else:
-            request = Request(scope, receive, send)
+            # F8: TachyonScope instead of Request — no Starlette __init__ overhead.
+            # as_request() materialises a full Request lazily if the endpoint needs it.
+            request = TachyonScope(scope, receive, send)
             response = await handler(request)
             await response(scope, receive, send)
 
@@ -268,10 +271,12 @@ class Tachyon:
             except HTTPException as exc:
                 exc_handler = self._exception_handlers.get(HTTPException)
                 if exc_handler is not None:
+                    # Exception handlers expect a Request — materialise lazily
+                    _req = request.as_request()
                     if asyncio.iscoroutinefunction(exc_handler):
-                        return await exc_handler(request, exc)
+                        return await exc_handler(_req, exc)
                     else:
-                        return exc_handler(request, exc)
+                        return exc_handler(_req, exc)
                 response = JSONResponse(
                     {"detail": exc.detail}, status_code=exc.status_code
                 )
@@ -283,10 +288,11 @@ class Tachyon:
             except Exception as exc:
                 for exc_class, exc_handler in self._exception_handlers.items():
                     if isinstance(exc, exc_class):
+                        _req = request.as_request()
                         if asyncio.iscoroutinefunction(exc_handler):
-                            return await exc_handler(request, exc)
+                            return await exc_handler(_req, exc)
                         else:
-                            return exc_handler(request, exc)
+                            return exc_handler(_req, exc)
                 return internal_server_error_response()
 
         # Phase 5b: wrap no-param, no-dep endpoints as ASGI handlers (skip Request creation)

--- a/tachyon_api/processing/dependencies.py
+++ b/tachyon_api/processing/dependencies.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, Type
 from starlette.requests import Request
 
 from ..di import Depends, _registry
+from .scope import TachyonScope
 
 
 class DependencyResolver:
@@ -85,7 +86,10 @@ class DependencyResolver:
         nested_kwargs = {}
         for param in sig.parameters.values():
             if param.annotation is Request:
-                nested_kwargs[param.name] = request
+                # Callable dep declared `request: Request` — give it the full Starlette object
+                nested_kwargs[param.name] = (
+                    request.as_request() if isinstance(request, TachyonScope) else request
+                )
             elif isinstance(param.default, Depends):
                 if param.default.dependency is not None:
                     nested_kwargs[param.name] = await self.resolve_callable_dependency(

--- a/tachyon_api/processing/parameters.py
+++ b/tachyon_api/processing/parameters.py
@@ -7,7 +7,6 @@ from typing import Any, Optional, Tuple
 
 import msgspec
 
-from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from ..models import Struct
@@ -21,6 +20,7 @@ from .compiler import (
     KIND_HEADER, KIND_COOKIE, KIND_FORM, KIND_FILE,
     KIND_PATH, KIND_PATH_IMPLICIT, KIND_DEP_CALLABLE, KIND_DEP_CLASS,
 )
+from .scope import TachyonScope
 
 _DEFAULT_MAX_BODY_SIZE = 10 * 1024 * 1024  # 10 MB
 
@@ -32,7 +32,7 @@ class ParameterProcessor:
     async def process_parameters(
         self,
         compiled: CompiledEndpoint,
-        request: Request,
+        request: TachyonScope,
         dependency_cache,
     ) -> Tuple[list, Optional[JSONResponse], Optional[BackgroundTasks]]:
         # Pre-allocate list of exact size — positional args for func(*args) call.
@@ -45,7 +45,8 @@ class ParameterProcessor:
             kind = p.kind
 
             if kind == KIND_REQUEST:
-                args[i] = request
+                # User declared `request: Request` — materialise the full Starlette object
+                args[i] = request.as_request()
 
             elif kind == KIND_BG:
                 if _bg is None:
@@ -115,7 +116,7 @@ class ParameterProcessor:
         return args, None, _bg
 
     async def _process_body(
-        self, p: ParamDescriptor, request: Request
+        self, p: ParamDescriptor, request: TachyonScope
     ) -> Tuple[Any, Optional[JSONResponse]]:
         max_body_size = getattr(self.app, "max_body_size", _DEFAULT_MAX_BODY_SIZE)
         cl = request.headers.get("content-length")
@@ -197,7 +198,7 @@ class ParameterProcessor:
         return None, validation_error_response(f"Missing required query parameter: {name}")
 
     def _process_header(
-        self, p: ParamDescriptor, request: Request
+        self, p: ParamDescriptor, request: TachyonScope
     ) -> Tuple[Any, Optional[JSONResponse]]:
         value = request.headers.get(p.effective_name)
         if value is not None:
@@ -207,7 +208,7 @@ class ParameterProcessor:
         return None, validation_error_response(f"Missing required header: {p.effective_name}")
 
     def _process_cookie(
-        self, p: ParamDescriptor, request: Request
+        self, p: ParamDescriptor, request: TachyonScope
     ) -> Tuple[Any, Optional[JSONResponse]]:
         value = request.cookies.get(p.effective_name)
         if value is not None:

--- a/tachyon_api/processing/parameters.pyx
+++ b/tachyon_api/processing/parameters.pyx
@@ -13,7 +13,6 @@ import cython
 import msgspec
 import typing
 
-from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from ..responses import validation_error_response
@@ -24,6 +23,7 @@ from .compiler import (
     KIND_HEADER, KIND_COOKIE, KIND_FORM, KIND_FILE,
     KIND_PATH, KIND_PATH_IMPLICIT, KIND_DEP_CALLABLE, KIND_DEP_CLASS,
 )
+from .scope import TachyonScope
 
 # C-level integer constants — avoids Python object lookup on each comparison
 cdef int _KIND_REQUEST       = KIND_REQUEST
@@ -66,7 +66,7 @@ cdef class ParameterProcessor:
             kind = p.kind  # int field from cdef class — direct C read
 
             if kind == _KIND_REQUEST:
-                args[i] = request
+                args[i] = request.as_request()
 
             elif kind == _KIND_BG:
                 if _bg is None:

--- a/tachyon_api/processing/scope.py
+++ b/tachyon_api/processing/scope.py
@@ -1,0 +1,100 @@
+"""
+TachyonScope — thin ASGI scope wrapper for the request hot path.
+
+Replaces Starlette's Request in process_parameters. Identical lazy properties
+but no class hierarchy, no __init__ assertions, and __slots__ for C-level
+attribute storage (faster None checks, smaller per-object footprint).
+
+call as_request() to get a full Starlette Request when explicitly needed:
+  - KIND_REQUEST params (user declared `request: Request`)
+  - Exception handlers that expect a Request
+  - Form parsing (delegates to Starlette's multipart implementation)
+"""
+from __future__ import annotations
+
+from http.cookies import SimpleCookie
+from typing import Any
+
+from starlette.datastructures import Headers, QueryParams
+from starlette.requests import Request
+
+
+class TachyonScope:
+    __slots__ = (
+        "_scope", "_receive", "_send",
+        "_body", "_query_params", "_headers", "_cookies",
+        "_form_data", "_request",
+    )
+
+    def __init__(self, scope: dict, receive: Any, send: Any) -> None:
+        self._scope = scope
+        self._receive = receive
+        self._send = send
+        self._body: bytes | None = None
+        self._query_params = None
+        self._headers = None
+        self._cookies = None
+        self._form_data = None
+        self._request: Request | None = None
+
+    # ── Properties read directly from scope / lazy-parsed ────────────────────
+
+    @property
+    def path_params(self) -> dict:
+        return self._scope["path_params"]
+
+    @property
+    def query_params(self) -> QueryParams:
+        if self._query_params is None:
+            self._query_params = QueryParams(self._scope.get("query_string", b""))
+        return self._query_params
+
+    @property
+    def headers(self) -> Headers:
+        if self._headers is None:
+            self._headers = Headers(scope=self._scope)
+        return self._headers
+
+    @property
+    def cookies(self) -> dict:
+        if self._cookies is None:
+            cookies: dict = {}
+            cookie_header = self.headers.get("cookie")
+            if cookie_header:
+                try:
+                    sc = SimpleCookie(cookie_header)
+                    for key, morsel in sc.items():
+                        cookies[key] = morsel.value
+                except Exception:
+                    pass
+            self._cookies = cookies
+        return self._cookies
+
+    # ── Async body / form ────────────────────────────────────────────────────
+
+    async def body(self) -> bytes:
+        if self._body is None:
+            chunks = []
+            while True:
+                message = await self._receive()
+                chunk = message.get("body", b"")
+                if chunk:
+                    chunks.append(chunk)
+                if not message.get("more_body", False):
+                    break
+            self._body = b"".join(chunks)
+        return self._body
+
+    async def form(self) -> Any:
+        # Multipart/form-url-encoded parsing is complex — delegate to Starlette
+        if self._form_data is None:
+            self._form_data = await self.as_request().form()
+        return self._form_data
+
+    # ── Escape hatch ─────────────────────────────────────────────────────────
+
+    def as_request(self) -> Request:
+        """Lazily materialise a full Starlette Request — only when needed."""
+        if self._request is None:
+            self._request = Request(self._scope, self._receive, self._send)
+        return self._request

--- a/tachyon_api/processing/scope.pyx
+++ b/tachyon_api/processing/scope.pyx
@@ -1,0 +1,92 @@
+# cython: language_level=3
+"""
+Cython-compiled TachyonScope.
+
+cdef class: fields are C-level struct members — None checks are direct C reads
+rather than Python attribute lookups through the slot descriptor protocol.
+"""
+from http.cookies import SimpleCookie
+
+from starlette.datastructures import Headers, QueryParams
+from starlette.requests import Request
+
+
+cdef class TachyonScope:
+    """Thin ASGI scope wrapper — replaces Starlette Request in the hot path."""
+
+    cdef public object _scope
+    cdef public object _receive
+    cdef public object _send
+    cdef object _body
+    cdef object _query_params
+    cdef object _headers
+    cdef object _cookies
+    cdef object _form_data
+    cdef object _request
+
+    def __init__(self, scope, receive, send):
+        self._scope = scope
+        self._receive = receive
+        self._send = send
+        self._body = None
+        self._query_params = None
+        self._headers = None
+        self._cookies = None
+        self._form_data = None
+        self._request = None
+
+    @property
+    def path_params(self):
+        return self._scope["path_params"]
+
+    @property
+    def query_params(self):
+        if self._query_params is None:
+            self._query_params = QueryParams(self._scope.get("query_string", b""))
+        return self._query_params
+
+    @property
+    def headers(self):
+        if self._headers is None:
+            self._headers = Headers(scope=self._scope)
+        return self._headers
+
+    @property
+    def cookies(self):
+        cdef dict cookies
+        if self._cookies is None:
+            cookies = {}
+            cookie_header = self.headers.get("cookie")
+            if cookie_header:
+                try:
+                    sc = SimpleCookie(cookie_header)
+                    for key, morsel in sc.items():
+                        cookies[key] = morsel.value
+                except Exception:
+                    pass
+            self._cookies = cookies
+        return self._cookies
+
+    async def body(self):
+        cdef list chunks
+        if self._body is None:
+            chunks = []
+            while True:
+                message = await self._receive()
+                chunk = message.get("body", b"")
+                if chunk:
+                    chunks.append(chunk)
+                if not message.get("more_body", False):
+                    break
+            self._body = b"".join(chunks)
+        return self._body
+
+    async def form(self):
+        if self._form_data is None:
+            self._form_data = await self.as_request().form()
+        return self._form_data
+
+    def as_request(self):
+        if self._request is None:
+            self._request = Request(self._scope, self._receive, self._send)
+        return self._request


### PR DESCRIPTION
## F8 — Eliminate Request object from hot path

Part of the v1.2.x performance roadmap. Target: −100ns/request. **Achieved: −176ns**.

### Changes

**New: `processing/scope.py` + `processing/scope.pyx`**
- `TachyonScope` — thin ASGI scope wrapper with `__slots__` / Cython `cdef class`
- Lazy properties: `path_params`, `query_params`, `headers`, `cookies`, `body()`, `form()`
- `as_request()` materialises a full Starlette `Request` only when explicitly needed

**`app.py`**
- `_trie_dispatch`: `Request(scope, receive, send)` → `TachyonScope(scope, receive, send)`
- Exception handlers: call `request.as_request()` on error paths only

**`processing/parameters.py` + `parameters.pyx`**
- `KIND_REQUEST`: `args[i] = request.as_request()` — lazy Request for endpoints that explicitly declare it
- Type hints updated: `TachyonScope` instead of `Request`

**`processing/dependencies.py`**
- Callable deps with `request: Request` param: `request.as_request()` injection

**`setup.py`**
- `scope.pyx` added to Cython extension build

### Benchmark

| | Time | 
|---|---|
| `TachyonScope()` | **221ns** |
| `Request()` (Starlette) | 398ns |
| **Saving** | **−176ns/req** |

### Tests
361 passing.