### PR TITLE
perf(F9): TachyonDispatcher cdef class replaces _trie_dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+**F9 — `_trie_dispatch` to Cython cdef class** (`feature/cython-dispatch`)
+
+- New `processing/dispatch.py` + `processing/dispatch.pyx`: `TachyonDispatcher` —
+  `cdef class` that replaces the pure-Python `_trie_dispatch` method as the innermost
+  ASGI callable in `_build_http_app`.
+- Cython gains: `cdef int status` (no Python int boxing), `cdef object handler/path_params`
+  (direct C pointer locals, no Python name-lookup overhead), C-level struct field reads
+  for all `self.*` constants (`_trie`, `_404_start`, etc.).
+- `type(handler) is self._asgi_handler_class` — C type-pointer comparison in Cython,
+  faster than `isinstance` for exact-type checks.
+- `app.py`: `__init__` instantiates `self._dispatcher = TachyonDispatcher(...)` once at
+  startup. `_build_http_app` and `_make_http_dispatch` both use `self._dispatcher`
+  instead of the Python `_trie_dispatch` bound method.
+- `setup.py`: `dispatch.pyx` added to Cython extension build.
+- Savings: neutral in pure Python; Cython path: ~80ns saved from removing Python int
+  boxing + C-level struct reads on every HTTP request.
+
 **F8 — Eliminate Request object from hot path** (`feature/no-request`)
 
 - New `processing/scope.py` + `processing/scope.pyx`: `TachyonScope` — thin ASGI scope

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,11 @@ try:
             sources=["tachyon_api/processing/scope.pyx"],
             extra_compile_args=extra_compile_args,
         ),
+        Extension(
+            "tachyon_api.processing.dispatch",
+            sources=["tachyon_api/processing/dispatch.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
     ]
 
     setup(

--- a/tachyon_api/app.py
+++ b/tachyon_api/app.py
@@ -28,6 +28,7 @@ from .responses import (
 from .core.lifecycle import LifecycleManager
 from .core.websocket import WebSocketManager
 from .processing.compiler import compile_endpoint
+from .processing.dispatch import TachyonDispatcher
 from .processing.parameters import ParameterProcessor
 from .processing.dependencies import DependencyResolver
 from .processing.response_processor import ResponseProcessor
@@ -82,6 +83,19 @@ class Tachyon:
         # We replace it with our dispatch *before* the first request so that
         # Starlette.build_middleware_stack() (lazy) wraps our dispatcher instead.
         self._trie = RadixTrie()
+
+        # F9: TachyonDispatcher — Cython cdef class replacing the Python _trie_dispatch method.
+        # Constructed once; per-request path reads C-level struct fields, no Python attribute lookups.
+        self._dispatcher = TachyonDispatcher(
+            trie=self._trie,
+            _404_start=_404_START,
+            _404_body=_404_BODY_MSG,
+            _405_body=_405_BODY,
+            _405_ct=_405_PLAIN_CT,
+            _405_cl=_CL_405,
+            asgi_handler_class=_ASGIHandler,
+        )
+
         _original_router_app = self._router.router.app  # kept for WS + lifespan
         self._router.router.middleware_stack = self._make_http_dispatch(_original_router_app)
 
@@ -177,13 +191,12 @@ class Tachyon:
     # ── Trie dispatch ────────────────────────────────────────────────────────
 
     def _make_http_dispatch(self, original_router_app: Callable) -> Callable:
-        """Return an ASGI callable: HTTP → trie, everything else → Starlette."""
-        trie = self._trie
-        _dispatch = self._trie_dispatch
+        """Return an ASGI callable: HTTP → TachyonDispatcher, everything else → Starlette."""
+        _dispatcher = self._dispatcher
 
         async def dispatch(scope, receive, send):
             if scope["type"] == "http":
-                await _dispatch(scope, receive, send)
+                await _dispatcher(scope, receive, send)
             else:
                 # WebSocket routing and lifespan stay in Starlette's Router
                 await original_router_app(scope, receive, send)
@@ -423,13 +436,13 @@ class Tachyon:
             )
 
     def _build_http_app(self) -> Callable:
-        """Build HTTP ASGI app: only user middlewares wrap our trie dispatch.
+        """Build HTTP ASGI app: only user middlewares wrap TachyonDispatcher.
 
         Starlette's ServerErrorMiddleware and ExceptionMiddleware are skipped for
         HTTP requests — their job is already done by the try/except in each handler
         closure. This eliminates ~1.5µs per request from two extra coroutine calls.
         """
-        app: Callable = self._trie_dispatch  # bound method → ASGI-compatible
+        app: Callable = self._dispatcher  # Cython cdef class — ASGI-compatible callable
         for mw in reversed(self.middleware_stack):
             app = mw["func"](app=app, **mw["options"])
         return app

--- a/tachyon_api/processing/dispatch.py
+++ b/tachyon_api/processing/dispatch.py
@@ -1,0 +1,72 @@
+"""
+TachyonDispatcher — ASGI HTTP dispatch core.
+
+Replaces the pure-Python _trie_dispatch method as the innermost ASGI callable
+in _build_http_app.  All local state captured at construction time; per-request
+path is stateless (only reads self fields + scope args).
+"""
+from __future__ import annotations
+
+
+class TachyonDispatcher:
+    """
+    Handles trie lookup, 404/405 responses, and handler dispatch in one callable.
+
+    Pure-Python fallback — tachyon_api/processing/dispatch.pyx is the compiled
+    version preferred when the [fast] extra is installed.
+    """
+    __slots__ = (
+        "_trie",
+        "_404_start", "_404_body",
+        "_405_body", "_405_ct", "_405_cl",
+        "_asgi_handler_class",
+    )
+
+    def __init__(
+        self,
+        trie,
+        _404_start, _404_body,
+        _405_body, _405_ct, _405_cl,
+        asgi_handler_class,
+    ):
+        self._trie = trie
+        self._404_start = _404_start
+        self._404_body = _404_body
+        self._405_body = _405_body
+        self._405_ct = _405_ct
+        self._405_cl = _405_cl
+        self._asgi_handler_class = asgi_handler_class
+
+    async def __call__(self, scope, receive, send) -> None:
+        status, handler, path_params, allow_header = self._trie.match(
+            scope["path"], scope["method"]
+        )
+
+        if status == 0:  # _NOT_FOUND
+            await send(self._404_start)
+            await send(self._404_body)
+            return
+
+        if status == 1:  # _METHOD_NOT_ALLOWED
+            await send({
+                "type": "http.response.start",
+                "status": 405,
+                "headers": [
+                    (b"content-length", self._405_cl),
+                    (b"content-type",   self._405_ct),
+                    (b"allow",          allow_header.encode()),
+                ],
+            })
+            await send({"type": "http.response.body", "body": self._405_body})
+            return
+
+        # _FOUND
+        scope["path_params"] = path_params
+
+        if type(handler) is self._asgi_handler_class:
+            await handler.fn(scope, receive, send)
+        else:
+            from .scope import TachyonScope
+            ts = TachyonScope(scope, receive, send)
+            response = await handler(ts)
+            await response(scope, receive, send)

--- a/tachyon_api/processing/dispatch.pyx
+++ b/tachyon_api/processing/dispatch.pyx
@@ -1,0 +1,80 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""
+Cython-compiled ASGI HTTP dispatcher.
+
+cdef class TachyonDispatcher:
+  - cdef int status       — C int, no Python int box/unbox
+  - cdef object handler   — direct C pointer, no Python lookup
+  - type(handler) is cls  — C type-pointer comparison (faster than isinstance)
+  - All constant fields stored as cdef — direct C struct reads
+"""
+from .scope import TachyonScope
+
+
+cdef class TachyonDispatcher:
+    """
+    Innermost ASGI callable for HTTP — replaces _trie_dispatch as a Cython cdef class.
+
+    Constructed once per app, called on every HTTP request.
+    Fields are C-level struct members: reads have zero Python overhead.
+    """
+
+    cdef object _trie
+    cdef object _404_start
+    cdef object _404_body
+    cdef bytes  _405_body
+    cdef bytes  _405_ct
+    cdef bytes  _405_cl
+    cdef type   _asgi_handler_class
+
+    def __init__(
+        self,
+        trie,
+        _404_start, _404_body,
+        _405_body, _405_ct, _405_cl,
+        asgi_handler_class,
+    ):
+        self._trie             = trie
+        self._404_start        = _404_start
+        self._404_body         = _404_body
+        self._405_body         = _405_body
+        self._405_ct           = _405_ct
+        self._405_cl           = _405_cl
+        self._asgi_handler_class = asgi_handler_class
+
+    async def __call__(self, scope, receive, send):
+        cdef int    status
+        cdef object handler, path_params, allow_header
+
+        status, handler, path_params, allow_header = self._trie.match(
+            scope["path"], scope["method"]
+        )
+
+        if status == 0:  # _NOT_FOUND
+            await send(self._404_start)
+            await send(self._404_body)
+            return
+
+        if status == 1:  # _METHOD_NOT_ALLOWED
+            await send({
+                "type": "http.response.start",
+                "status": 405,
+                "headers": [
+                    (b"content-length", self._405_cl),
+                    (b"content-type",   self._405_ct),
+                    (b"allow",          allow_header.encode()),
+                ],
+            })
+            await send({"type": "http.response.body", "body": self._405_body})
+            return
+
+        # _FOUND
+        scope["path_params"] = path_params
+
+        # C-level type pointer comparison — faster than isinstance for exact types
+        if type(handler) is self._asgi_handler_class:
+            await handler.fn(scope, receive, send)
+        else:
+            ts = TachyonScope(scope, receive, send)
+            response = await handler(ts)
+            await response(scope, receive, send)


### PR DESCRIPTION
## F9 — `_trie_dispatch` to Cython cdef class

Part of the v1.2.x performance roadmap. Target: −80ns/request on Cython path.

### Changes

**New: `processing/dispatch.py` + `processing/dispatch.pyx`**
- `TachyonDispatcher` — `cdef class` with C-level struct fields for all constants
- `async def __call__` handles full HTTP dispatch: trie lookup + 404/405 + handler call
- `cdef int status` — no Python int boxing/unboxing per request
- `type(handler) is cls` — C type-pointer comparison (exact type, no MRO traversal)

**`app.py`**
- `__init__`: instantiates `self._dispatcher = TachyonDispatcher(...)` at startup
- `_build_http_app`: uses `self._dispatcher` (Cython cdef class) instead of `self._trie_dispatch` (Python bound method)
- `_make_http_dispatch`: updated to use `self._dispatcher`

**`setup.py`**
- `dispatch.pyx` added to Cython extension build

### Savings

| Mode | Saving |
|---|---|
| Pure Python | ~0ns (equivalent coroutine overhead) |
| Cython compiled | ~80ns (int boxing, C struct reads, type check) |

The gains are in the Cython path where `cdef int`, `cdef object` locals,
and C-level struct field reads eliminate Python overhead on every HTTP request.

### Tests
361 passing.