### PR TITLE
release: v1.2.0 — Python/Cython ceiling (F6-F12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased] — v1.2.0
+## [1.2.0] - 2026-05-22
+
+This release brings **F6 through F12** — the complete Python/Cython optimisation
+roadmap targeting the theoretical ceiling before v2.x (Rust/C core).
+
+### Summary
+
+| Metric | v1.1.0 | v1.2.0 | Δ |
+|---|---:|---:|---:|
+| FULL HANDLER cycle (µs) | 1.16µs | **1.05µs** | **−9%** |
+| `process_parameters` path+query | 0.82µs | **0.56µs** | **−32%** |
+| `process_parameters` body POST | 1.28µs | **0.79µs** | **−38%** |
+| Total throughput (100 conns) | 335,626 req/s | **345,046 req/s** | **+2.8%** |
+| Overall speedup vs FastAPI | 5.61x | **5.50x** | (FastAPI also improved) |
+
+Gains are larger at realistic production concurrency (c=4–50): **+5–8%** on F12b paths.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ Benchmarked against **FastAPI 0.136.1 (Pydantic v2)** · 1 worker · 100 concurr
 
 | Scenario | FastAPI | Tachyon | Speedup |
 |---|---:|---:|---:|
-| Hello World | 10,225 req/s | **49,946 req/s** | **4.88x** |
-| Path + query params | 7,127 req/s | **37,943 req/s** | **5.32x** |
-| Body validation (Struct) | 8,257 req/s | **41,286 req/s** | **5.00x** |
-| Nested body (complex Struct) | 7,949 req/s | **40,304 req/s** | **5.07x** |
-| Response model serialization | 6,749 req/s | **47,202 req/s** | **6.99x** |
-| Header param + auth | 8,648 req/s | **45,531 req/s** | **5.26x** |
-| Dependency injection | 6,337 req/s | **46,168 req/s** | **7.28x** |
-| Multiple query params | 6,279 req/s | **34,414 req/s** | **5.48x** |
-| **Total throughput** | **61,571 req/s** | **342,794 req/s** | **5.57x** |
+| Hello World | 10,378 req/s | **49,521 req/s** | **4.77x** |
+| Path + query params | 7,294 req/s | **37,991 req/s** | **5.21x** |
+| Body validation (Struct) | 8,533 req/s | **41,507 req/s** | **4.86x** |
+| Nested body (complex Struct) | 8,205 req/s | **40,816 req/s** | **4.97x** |
+| Response model serialization | 6,766 req/s | **47,777 req/s** | **7.06x** |
+| Header param + auth | 8,705 req/s | **46,013 req/s** | **5.29x** |
+| Dependency injection | 6,491 req/s | **46,940 req/s** | **7.23x** |
+| Multiple query params | 6,325 req/s | **34,481 req/s** | **5.45x** |
+| **Total throughput** | **62,697 req/s** | **345,046 req/s** | **5.50x** |
 
-**Latency:** ~2.4ms (Tachyon) vs ~14ms (FastAPI) on average.
+**Latency:** ~2.3ms (Tachyon) vs ~13ms (FastAPI) on average.
 
 > Benchmark code in [`benchmark/`](./benchmark/). Run with `bash benchmark/run_benchmark.sh`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.1.0"
+version = "1.2.0"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## v1.2.0 — Python/Cython optimisation ceiling

### Changes
- `pyproject.toml`: bump to `1.2.0`
- `README.md`: benchmark table updated with fresh numbers
- `CHANGELOG.md`: `[Unreleased]` → `[1.2.0] - 2026-05-22`, summary table added

### What's in this release (F6–F12)

| Phase | Change | Measured gain |
|---|---|---|
| F6 | Zero-allocation routing — memchr + lazy path_params | −200ns routing |
| F7 | List args instead of kwargs dict + positional dispatch | −72ns call overhead |
| F8 | TachyonScope replaces Starlette Request | −176ns per parameterised req |
| F9 | TachyonDispatcher cdef class | −80ns (Cython path) |
| F10 | Pre-built header tuples _CL_TUPLE_CACHE + _CT_TUPLE | −79ns per response |
| F11 | memchr in trie + strtol/strtod in parameters | −68ns/segment, −40ns/int param |
| F12 | TachyonServer + _server_fast.pyx | +5–8% at prod concurrency |

### Benchmark (Apple Silicon · Python 3.10 · Cython compiled · 100 conns)

| Scenario | FastAPI | Tachyon | Speedup |
|---|---|---|---|
| Hello World | 10,378 | 49,521 | 4.77x |
| Response model | 6,766 | 47,777 | **7.06x** |
| Dependency injection | 6,491 | 46,940 | **7.23x** |
| **Total** | **62,697** | **345,046** | **5.50x** |

### Tests
361 passing.