### PR TITLE
feat(cli): tachyon run, routes, middleware, .env, name validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,15 +231,26 @@ async def websocket(ws):
 ## 🔧 CLI Tools
 
 ```bash
-# Create new project
+# Create project (generates .env.example, config.py with dotenv, clean arch)
 tachyon new my-api
 
-# Generate module
-tachyon generate service users --crud
+# Start development server (uvloop + httptools auto-detected, reload on)
+tachyon run
+
+# List all registered routes
+tachyon routes
+
+# Generate a full CRUD module
+tachyon g service users --crud
+
+# Generate an ASGI middleware skeleton
+tachyon g middleware auth
 
 # Code quality
 tachyon lint all
 ```
+
+**Name validation:** hyphens auto-converted to underscores (`my-api` → `my_api`), Python keywords rejected with a clear error.
 
 👉 [Full CLI documentation](./docs/12-cli.md)
 

--- a/docs/12-cli.md
+++ b/docs/12-cli.md
@@ -1,148 +1,269 @@
 # 12. CLI Tools
 
-> Herramientas de línea de comandos para Tachyon
+> Command-line toolkit for Tachyon projects — scaffolding, code generation, development server, and code quality.
 
-## 📦 Instalación
+## Installation
 
-El CLI viene incluido con tachyon-api:
+The CLI is included with `tachyon-api`:
 
 ```bash
 pip install tachyon-api
-```
-
-Verificar instalación:
-
-```bash
 tachyon --help
 ```
 
 ---
 
+## Command Overview
+
+| Command | Description |
+|---------|-------------|
+| `tachyon new <name>` | Create a new project |
+| `tachyon run [app]` | Start the development / production server |
+| `tachyon routes [app]` | List all registered routes |
+| `tachyon g service <name>` | Generate a full module (controller + service + repo + dto + tests) |
+| `tachyon g controller <name>` | Generate a controller only |
+| `tachyon g repository <name>` | Generate a repository only |
+| `tachyon g dto <name>` | Generate a DTO file only |
+| `tachyon g middleware <name>` | Generate an ASGI middleware skeleton |
+| `tachyon openapi export <app>` | Export OpenAPI schema to JSON |
+| `tachyon openapi validate <file>` | Validate an OpenAPI schema file |
+| `tachyon lint check` | Check code quality (ruff) |
+| `tachyon lint fix` | Auto-fix linting issues |
+| `tachyon lint format` | Format code |
+| `tachyon lint all` | Lint + format in one step |
+| `tachyon version` | Show installed version |
+
+---
+
 ## 🏗️ tachyon new
 
-Crear un nuevo proyecto:
+Create a new Tachyon project with clean architecture.
 
 ```bash
 tachyon new my-api
+tachyon new my-api --path ./projects
 ```
 
-### Estructura generada:
+**Name rules:** hyphens are converted to underscores (`my-api` → `my_api`), Python keywords are rejected.
+
+### Generated structure
 
 ```
 my-api/
-├── app.py                  # Entry point
-├── config.py               # Configuración
-├── requirements.txt        # Dependencias
-├── modules/                # Feature modules
+├── .env.example            # Environment variable template — copy to .env
+├── app.py                  # Application entry point
+├── config.py               # Settings (reads from .env via python-dotenv)
+├── requirements.txt        # Dependencies
+├── modules/                # Feature modules (one per domain)
 │   └── __init__.py
-├── shared/                 # Código compartido
+├── shared/                 # Shared utilities
 │   ├── __init__.py
-│   ├── exceptions.py       # HTTPException helpers
-│   └── dependencies.py     # Shared dependencies
+│   ├── exceptions.py       # Typed HTTP exceptions (NotFoundError, etc.)
+│   └── dependencies.py     # Shared DI dependencies
 └── tests/
     ├── __init__.py
-    └── conftest.py         # Pytest fixtures
+    └── conftest.py         # Pytest fixtures (async client pre-configured)
 ```
 
-### Opciones:
+### Next steps after `tachyon new`
 
 ```bash
-# Crear en directorio específico
-tachyon new my-api --path ./projects
+cd my-api
+cp .env.example .env          # configure your environment
+pip install -r requirements.txt
+tachyon run                   # starts at http://localhost:8000
 ```
 
 ---
 
-## 🔧 tachyon generate (g)
+## ▶ tachyon run
 
-Generar componentes de código.
+Start the server with sensible defaults — wraps uvicorn with auto-detected uvloop and httptools.
 
-### Service Completo
+```bash
+# Development (auto-reload, single worker)
+tachyon run
+
+# Custom app / port
+tachyon run app:app --port 9000
+
+# Production (no reload, multiple workers)
+tachyon run --prod --workers 4
+
+# Custom host
+tachyon run --host 127.0.0.1
+
+# TachyonServer — enables F12b direct transport writes
+tachyon run --tachyon-server
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `app` | `app:app` | Module:attribute path to the ASGI app |
+| `--host` / `-h` | `0.0.0.0` | Bind host |
+| `--port` / `-p` | `8000` | Bind port |
+| `--reload / --no-reload` | `True` | Auto-reload on file changes |
+| `--workers` / `-w` | `1` | Worker processes |
+| `--prod` | `False` | Production mode — disables reload, sets workers to 4 if unset |
+| `--tachyon-server` | `False` | Use `TachyonHTTPProtocol` for direct socket writes |
+
+> **Note:** `--prod` overrides `--reload` regardless of flags order.
+
+---
+
+## 📋 tachyon routes
+
+Inspect all registered routes without starting the server.
+
+```bash
+tachyon routes          # reads app:app in current directory
+tachyon routes myapp:app
+```
+
+Output example:
+
+```
+Registered routes:
+  ────────────────────────────────────────
+  METHOD    PATH                    NAME
+  ────────────────────────────────────────
+  GET       /                       root
+  GET       /health                 health
+  GET       /users                  list_users
+  GET       /users/{id}             get_user
+  POST      /users                  create_user
+  PUT       /users/{id}             update_user
+  DELETE    /users/{id}             delete_user
+  ────────────────────────────────────────
+  7 route(s) total.
+```
+
+Methods are colour-coded: GET=green, POST=blue, PUT=yellow, PATCH=cyan, DELETE=red.
+
+---
+
+## 🔧 tachyon generate (alias: g)
+
+Generate code components. All names accept hyphens (auto-converted to snake_case).
+
+### Full service module
 
 ```bash
 tachyon g service users
-# o
-tachyon generate service users
+tachyon generate service users   # same thing
 ```
 
-Genera:
+Generates:
 
 ```
 modules/users/
 ├── __init__.py
-├── users_controller.py     # Router con endpoints
+├── users_controller.py     # Router with endpoints
 ├── users_service.py        # Business logic (@injectable)
-├── users_repository.py     # Data access
+├── users_repository.py     # Data access layer
 ├── users_dto.py            # Struct models
 └── tests/
     └── test_users_service.py
 ```
 
-### Con CRUD
+Then register the router in `app.py`:
+
+```python
+from modules.users import router as users_router
+app.include_router(users_router)
+```
+
+### With CRUD endpoints (`--crud`)
 
 ```bash
 tachyon g service products --crud
 ```
 
-Genera endpoints CRUD:
-- `GET /products` - List
-- `GET /products/{id}` - Get one
-- `POST /products` - Create
-- `PUT /products/{id}` - Update
-- `DELETE /products/{id}` - Delete
+Adds full CRUD to the controller and service:
 
-### Sin Tests
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/products` | List with `skip` + `limit` pagination |
+| `GET` | `/products/{id}` | Get one by ID |
+| `POST` | `/products` | Create (body: `ProductCreate`) |
+| `PUT` | `/products/{id}` | Update (body: `ProductUpdate`) |
+| `DELETE` | `/products/{id}` | Delete |
+
+### Options
 
 ```bash
-tachyon g service auth --no-tests
+tachyon g service auth --no-tests    # skip test file
+tachyon g service users --path src/modules   # custom output path
 ```
 
-### Componentes Individuales
+### Individual components
 
 ```bash
-# Solo controller
-tachyon g controller orders
-
-# Solo repository
-tachyon g repository orders
-tachyon g repo orders  # alias
-
-# Solo DTOs
-tachyon g dto orders
+tachyon g controller orders    # only the controller file
+tachyon g repository orders    # only the repository file
+tachyon g repo orders          # alias for repository
+tachyon g dto orders           # only the DTO file
 ```
 
-### Path Custom
+---
+
+## 🔒 tachyon generate middleware
+
+Generate an ASGI middleware skeleton.
 
 ```bash
-tachyon g service users --path src/modules
+tachyon g middleware auth
+tachyon g middleware rate_limit --path ./middlewares
+```
+
+Generates `middlewares/auth_middleware.py`:
+
+```python
+class AuthMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        request = Request(scope, receive)
+        response = await self.process(request)
+        if response is not None:
+            await response(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
+    async def process(self, request: Request) -> Response | None:
+        # Return a Response to short-circuit, or None to continue
+        return None
+```
+
+Register in `app.py`:
+
+```python
+from middlewares.auth_middleware import AuthMiddleware
+app.add_middleware(AuthMiddleware)
 ```
 
 ---
 
 ## 📄 tachyon openapi
 
-Utilidades para OpenAPI schema.
-
-### Exportar Schema
+### Export schema
 
 ```bash
-# A stdout
-tachyon openapi export app:app
-
-# A archivo
-tachyon openapi export app:app -o openapi.json
-
-# Con indentación
-tachyon openapi export app:app -o openapi.json --indent 4
+tachyon openapi export app:app               # stdout
+tachyon openapi export app:app -o schema.json
+tachyon openapi export app:app -o schema.json --indent 4
 ```
 
-### Validar Schema
+### Validate schema
 
 ```bash
-tachyon openapi validate openapi.json
+tachyon openapi validate schema.json
 ```
 
-Output:
 ```
 ✅ Schema is valid!
    OpenAPI version: 3.0.0
@@ -154,86 +275,31 @@ Output:
 
 ## 🔍 tachyon lint
 
-Wrapper sobre ruff para calidad de código.
-
-### Check
+Wrapper over [ruff](https://docs.astral.sh/ruff/) for code quality.
 
 ```bash
-# Verificar todo
-tachyon lint check
+tachyon lint check              # check all
+tachyon lint check ./modules    # specific path
+tachyon lint check --fix        # auto-fix
+tachyon lint check --watch      # watch mode
 
-# Directorio específico
-tachyon lint check ./modules
+tachyon lint fix                # fix all
+tachyon lint fix --unsafe       # include unsafe fixes
 
-# Con auto-fix
-tachyon lint check --fix
+tachyon lint format             # format
+tachyon lint format --check     # dry-run (no writes)
+tachyon lint format --diff      # show diff
 
-# Watch mode
-tachyon lint check --watch
+tachyon lint all                # lint + format together
+tachyon lint all --no-fix       # report only
 ```
 
-### Fix
-
-```bash
-# Fix seguro
-tachyon lint fix
-
-# Fix incluyendo unsafe
-tachyon lint fix --unsafe
-```
-
-### Format
-
-```bash
-# Formatear
-tachyon lint format
-
-# Solo verificar (no modifica)
-tachyon lint format --check
-
-# Ver diff
-tachyon lint format --diff
-```
-
-### All (Lint + Format)
-
-```bash
-# Todo junto
-tachyon lint all
-
-# Sin auto-fix (solo reportar)
-tachyon lint all --no-fix
-```
-
----
-
-## 📋 Resumen de Comandos
-
-| Comando | Descripción |
-|---------|-------------|
-| `tachyon new <name>` | Crear proyecto |
-| `tachyon g service <name>` | Generar módulo completo |
-| `tachyon g controller <name>` | Generar solo controller |
-| `tachyon g repository <name>` | Generar solo repository |
-| `tachyon g dto <name>` | Generar solo DTOs |
-| `tachyon openapi export <app>` | Exportar OpenAPI |
-| `tachyon openapi validate <file>` | Validar schema |
-| `tachyon lint check` | Verificar código |
-| `tachyon lint fix` | Arreglar issues |
-| `tachyon lint format` | Formatear código |
-| `tachyon lint all` | Check + format |
-| `tachyon version` | Ver versión |
-
----
-
-## ⚙️ Configuración ruff
-
-Crear `ruff.toml` o en `pyproject.toml`:
+### Recommended `ruff.toml`
 
 ```toml
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP"]
@@ -245,7 +311,35 @@ quote-style = "double"
 
 ---
 
-## 🔗 Próximos Pasos
+## ⚙️ Environment & configuration
 
-- [Request Lifecycle](./13-request-lifecycle.md) - Entender el flujo
-- [Best Practices](./15-best-practices.md) - Patrones recomendados
+`tachyon new` generates a `.env.example` alongside `config.py`:
+
+```bash
+# .env.example
+APP_NAME=Tachyon API
+VERSION=0.1.0
+DEBUG=true
+HOST=0.0.0.0
+PORT=8000
+# DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+```
+
+```bash
+cp .env.example .env   # create your local env file
+```
+
+`config.py` loads `.env` automatically via `python-dotenv` (gracefully skipped in production where env vars are set directly):
+
+```python
+from config import settings
+print(settings.APP_NAME)  # reads from .env or environment
+```
+
+---
+
+## 🔗 Related
+
+- [Architecture](./02-architecture.md) — clean architecture patterns
+- [Dependency Injection](./03-dependency-injection.md) — `@injectable` and `Depends()`
+- [Testing](./11-testing.md) — `TachyonTestClient` and fixtures

--- a/tachyon_api/cli/commands/generate.py
+++ b/tachyon_api/cli/commands/generate.py
@@ -1,7 +1,9 @@
 """
-tachyon generate - Generate components (service, controller, repository, dto)
+tachyon generate - Generate components (service, controller, repository, dto, middleware)
 """
 
+import keyword
+import re
 import typer
 from pathlib import Path
 from typing import Optional
@@ -11,22 +13,51 @@ from ..templates import ServiceTemplates
 app = typer.Typer(no_args_is_help=True)
 
 
+# ── Name helpers ──────────────────────────────────────────────────────────────
+
 def _to_class_name(name: str) -> str:
-    """Convert snake_case or kebab-case to PascalCase."""
-    return "".join(word.capitalize() for word in name.replace("-", "_").split("_"))
+    return "".join(w.capitalize() for w in name.replace("-", "_").split("_"))
 
 
 def _to_snake_case(name: str) -> str:
-    """Ensure name is in snake_case."""
     return name.replace("-", "_").lower()
 
 
+def _validate_name(name: str, kind: str = "module") -> str:
+    """Normalise and validate a component name."""
+    normalised = _to_snake_case(name)
+
+    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', normalised):
+        typer.secho(
+            f"❌ '{name}' is not a valid Python identifier for a {kind} name.\n"
+            f"   Use letters, digits, and underscores only.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    if keyword.iskeyword(normalised):
+        typer.secho(
+            f"❌ '{normalised}' is a Python reserved keyword.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    if normalised != name:
+        typer.secho(
+            f"  ℹ  Name normalised: '{name}' → '{normalised}'",
+            fg=typer.colors.BRIGHT_BLACK,
+        )
+
+    return normalised
+
+
 def _create_file(path: Path, content: str, name: str):
-    """Create a file and print status."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
     typer.echo(f"  📄 Created {name}")
 
+
+# ── Commands ──────────────────────────────────────────────────────────────────
 
 @app.command()
 def service(
@@ -34,11 +65,10 @@ def service(
     path: Optional[Path] = typer.Option(
         None, "--path", "-p", help="Base path for modules (default: ./modules)"
     ),
-    no_tests: bool = typer.Option(
-        False, "--no-tests", help="Skip test file generation"
-    ),
+    no_tests: bool = typer.Option(False, "--no-tests", help="Skip test file generation"),
     crud: bool = typer.Option(
-        False, "--crud", help="Generate with basic CRUD operations"
+        False, "--crud",
+        help="Generate with full CRUD (list, get, create, update, delete)",
     ),
 ):
     """
@@ -51,8 +81,8 @@ def service(
         tachyon g service products --crud
         tachyon g service users --path src/modules
     """
-    snake_name = _to_snake_case(name)
-    class_name = _to_class_name(name)
+    snake_name = _validate_name(name, "service")
+    class_name = _to_class_name(snake_name)
 
     base_path = path or Path.cwd() / "modules"
     service_path = base_path / snake_name
@@ -63,30 +93,20 @@ def service(
 
     typer.echo(f"\n🔧 Generating service: {typer.style(snake_name, bold=True)}\n")
 
-    # Create directory
     service_path.mkdir(parents=True, exist_ok=True)
     tests_path = service_path / "tests"
     tests_path.mkdir(exist_ok=True)
 
-    # Generate files
     files = {
-        "__init__.py": ServiceTemplates.init(snake_name, class_name),
-        f"{snake_name}_controller.py": ServiceTemplates.controller(
-            snake_name, class_name, crud
-        ),
-        f"{snake_name}_service.py": ServiceTemplates.service(
-            snake_name, class_name, crud
-        ),
-        f"{snake_name}_repository.py": ServiceTemplates.repository(
-            snake_name, class_name, crud
-        ),
-        f"{snake_name}_dto.py": ServiceTemplates.dto(snake_name, class_name, crud),
+        "__init__.py":               ServiceTemplates.init(snake_name, class_name),
+        f"{snake_name}_controller.py": ServiceTemplates.controller(snake_name, class_name, crud),
+        f"{snake_name}_service.py":    ServiceTemplates.service(snake_name, class_name, crud),
+        f"{snake_name}_repository.py": ServiceTemplates.repository(snake_name, class_name, crud),
+        f"{snake_name}_dto.py":        ServiceTemplates.dto(snake_name, class_name, crud),
     }
-
     for filename, content in files.items():
         _create_file(service_path / filename, content, filename)
 
-    # Generate tests
     if not no_tests:
         _create_file(tests_path / "__init__.py", "", "tests/__init__.py")
         _create_file(
@@ -98,9 +118,9 @@ def service(
     typer.echo(
         f"\n✅ Service {typer.style(snake_name, bold=True, fg=typer.colors.GREEN)} generated!"
     )
-    typer.echo("\n📖 Don't forget to register in app.py:")
-    typer.echo(f"   from modules.{snake_name} import router as {snake_name}_router")
-    typer.echo(f"   app.include_router({snake_name}_router)")
+    typer.echo("\n📖 Register in app.py:")
+    typer.secho(f"   from modules.{snake_name} import router as {snake_name}_router", fg=typer.colors.CYAN)
+    typer.secho(f"   app.include_router({snake_name}_router)", fg=typer.colors.CYAN)
     typer.echo()
 
 
@@ -115,51 +135,50 @@ def controller(
     Example:
         tachyon g controller users
     """
-    snake_name = _to_snake_case(name)
-    class_name = _to_class_name(name)
-
-    base_path = path or Path.cwd() / "modules" / snake_name
+    snake_name = _validate_name(name, "controller")
+    class_name = _to_class_name(snake_name)
+    base_path = (path or Path.cwd() / "modules" / snake_name)
     base_path.mkdir(parents=True, exist_ok=True)
 
     typer.echo(f"\n📡 Generating controller: {snake_name}\n")
-
     _create_file(
         base_path / f"{snake_name}_controller.py",
         ServiceTemplates.controller(snake_name, class_name, False),
         f"{snake_name}_controller.py",
     )
-
     typer.echo("\n✅ Controller generated!")
 
 
-@app.command("repo")
-@app.command("repository")
-def repository(
-    name: str = typer.Argument(..., help="Repository name"),
-    path: Optional[Path] = typer.Option(None, "--path", "-p"),
-):
-    """
-    🗄️  Generate a repository file.
-
-    Example:
-        tachyon g repository users
-        tachyon g repo products
-    """
-    snake_name = _to_snake_case(name)
-    class_name = _to_class_name(name)
-
+def _do_repository(name: str, path: Optional[Path]) -> None:
+    snake_name = _validate_name(name, "repository")
+    class_name = _to_class_name(snake_name)
     base_path = path or Path.cwd() / "modules" / snake_name
     base_path.mkdir(parents=True, exist_ok=True)
-
     typer.echo(f"\n🗄️  Generating repository: {snake_name}\n")
-
     _create_file(
         base_path / f"{snake_name}_repository.py",
         ServiceTemplates.repository(snake_name, class_name, False),
         f"{snake_name}_repository.py",
     )
-
     typer.echo("\n✅ Repository generated!")
+
+
+@app.command("repository")
+def repository(
+    name: str = typer.Argument(..., help="Repository name"),
+    path: Optional[Path] = typer.Option(None, "--path", "-p"),
+):
+    """🗄️  Generate a repository file.\n\nExample: tachyon g repository users"""
+    _do_repository(name, path)
+
+
+@app.command("repo", hidden=True)
+def repo(
+    name: str = typer.Argument(..., help="Repository name"),
+    path: Optional[Path] = typer.Option(None, "--path", "-p"),
+):
+    """Alias for 'repository'."""
+    _do_repository(name, path)
 
 
 @app.command()
@@ -173,18 +192,49 @@ def dto(
     Example:
         tachyon g dto users
     """
-    snake_name = _to_snake_case(name)
-    class_name = _to_class_name(name)
-
-    base_path = path or Path.cwd() / "modules" / snake_name
+    snake_name = _validate_name(name, "dto")
+    class_name = _to_class_name(snake_name)
+    base_path = (path or Path.cwd() / "modules" / snake_name)
     base_path.mkdir(parents=True, exist_ok=True)
 
     typer.echo(f"\n📦 Generating DTO: {snake_name}\n")
-
     _create_file(
         base_path / f"{snake_name}_dto.py",
         ServiceTemplates.dto(snake_name, class_name, False),
         f"{snake_name}_dto.py",
     )
-
     typer.echo("\n✅ DTO generated!")
+
+
+@app.command()
+def middleware(
+    name: str = typer.Argument(..., help="Middleware name (e.g., 'auth', 'logging')"),
+    path: Optional[Path] = typer.Option(
+        None, "--path", "-p", help="Output directory (default: ./middlewares)"
+    ),
+):
+    """
+    🔒 Generate an ASGI middleware skeleton.
+
+    Example:
+        tachyon g middleware auth
+        tachyon g middleware rate_limit
+    """
+    snake_name = _validate_name(name, "middleware")
+    class_name = _to_class_name(snake_name)
+    base_path = path or Path.cwd() / "middlewares"
+    base_path.mkdir(parents=True, exist_ok=True)
+
+    filename = f"{snake_name}_middleware.py"
+    typer.echo(f"\n🔒 Generating middleware: {snake_name}\n")
+    _create_file(
+        base_path / filename,
+        ServiceTemplates.middleware(snake_name, class_name),
+        filename,
+    )
+
+    typer.echo(f"\n✅ Middleware {typer.style(class_name + 'Middleware', bold=True, fg=typer.colors.GREEN)} generated!")
+    typer.echo("\n📖 Register in app.py:")
+    typer.secho(f"   from middlewares.{snake_name}_middleware import {class_name}Middleware", fg=typer.colors.CYAN)
+    typer.secho(f"   app.add_middleware({class_name}Middleware)", fg=typer.colors.CYAN)
+    typer.echo()

--- a/tachyon_api/cli/commands/new.py
+++ b/tachyon_api/cli/commands/new.py
@@ -2,11 +2,46 @@
 tachyon new - Create new project with clean architecture
 """
 
+import keyword
+import re
 import typer
 from pathlib import Path
 from typing import Optional
 
 from ..templates import ProjectTemplates
+
+
+def _validate_name(name: str) -> str:
+    """
+    Validate and normalise a project/module name.
+    - Convert hyphens to underscores (my-api → my_api)
+    - Reject Python keywords, names starting with digits, or invalid chars
+    Returns the normalised snake_case name.
+    """
+    normalised = name.replace("-", "_").lower()
+
+    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', normalised):
+        typer.secho(
+            f"❌ '{name}' is not a valid Python identifier.\n"
+            f"   Use letters, digits, and underscores only — no spaces or special chars.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    if keyword.iskeyword(normalised):
+        typer.secho(
+            f"❌ '{normalised}' is a Python reserved keyword and cannot be used as a project name.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    if normalised != name:
+        typer.secho(
+            f"  ℹ  Name normalised: '{name}' → '{normalised}'",
+            fg=typer.colors.BRIGHT_BLACK,
+        )
+
+    return normalised
 
 
 def create_project(name: str, parent_path: Optional[Path] = None):
@@ -15,6 +50,7 @@ def create_project(name: str, parent_path: Optional[Path] = None):
 
     Structure:
         my-api/
+        ├── .env.example
         ├── app.py
         ├── config.py
         ├── requirements.txt
@@ -28,11 +64,11 @@ def create_project(name: str, parent_path: Optional[Path] = None):
             ├── __init__.py
             └── conftest.py
     """
-    # Determine project path
+    name = _validate_name(name)
+
     base_path = parent_path or Path.cwd()
     project_path = base_path / name
 
-    # Check if already exists
     if project_path.exists():
         typer.secho(f"❌ Directory '{name}' already exists!", fg=typer.colors.RED)
         raise typer.Exit(1)
@@ -40,33 +76,27 @@ def create_project(name: str, parent_path: Optional[Path] = None):
     typer.echo(f"\n🚀 Creating Tachyon project: {typer.style(name, bold=True)}\n")
 
     # Create directory structure
-    directories = [
-        project_path,
-        project_path / "modules",
-        project_path / "shared",
-        project_path / "tests",
-    ]
-
-    for directory in directories:
+    for directory in [project_path, project_path / "modules",
+                      project_path / "shared", project_path / "tests"]:
         directory.mkdir(parents=True, exist_ok=True)
         typer.echo(f"  📁 Created {directory.relative_to(base_path)}/")
 
     # Create files
     files = {
-        "app.py": ProjectTemplates.APP,
-        "config.py": ProjectTemplates.CONFIG,
-        "requirements.txt": ProjectTemplates.REQUIREMENTS,
-        "modules/__init__.py": ProjectTemplates.MODULES_INIT,
-        "shared/__init__.py": ProjectTemplates.SHARED_INIT,
-        "shared/exceptions.py": ProjectTemplates.SHARED_EXCEPTIONS,
+        ".env.example":           ProjectTemplates.ENV_EXAMPLE,
+        "app.py":                 ProjectTemplates.APP,
+        "config.py":              ProjectTemplates.CONFIG,
+        "requirements.txt":       ProjectTemplates.REQUIREMENTS,
+        "modules/__init__.py":    ProjectTemplates.MODULES_INIT,
+        "shared/__init__.py":     ProjectTemplates.SHARED_INIT,
+        "shared/exceptions.py":   ProjectTemplates.SHARED_EXCEPTIONS,
         "shared/dependencies.py": ProjectTemplates.SHARED_DEPENDENCIES,
-        "tests/__init__.py": "",
-        "tests/conftest.py": ProjectTemplates.TESTS_CONFTEST,
+        "tests/__init__.py":      "",
+        "tests/conftest.py":      ProjectTemplates.TESTS_CONFTEST,
     }
 
     for file_path, content in files.items():
-        full_path = project_path / file_path
-        full_path.write_text(content)
+        (project_path / file_path).write_text(content)
         typer.echo(f"  📄 Created {file_path}")
 
     # Success message
@@ -75,20 +105,21 @@ def create_project(name: str, parent_path: Optional[Path] = None):
     )
     typer.echo(f"\n{'─'*50}")
     typer.echo("📖 Next steps:\n")
-    typer.secho(f"  1. Enter the project directory:", fg=typer.colors.BRIGHT_WHITE)
+    typer.secho("  1. Enter the project directory:", fg=typer.colors.BRIGHT_WHITE)
     typer.secho(f"     cd {name}", fg=typer.colors.CYAN)
     typer.echo()
-    typer.secho("  2. Install dependencies:", fg=typer.colors.BRIGHT_WHITE)
+    typer.secho("  2. Copy .env and install dependencies:", fg=typer.colors.BRIGHT_WHITE)
+    typer.secho("     cp .env.example .env", fg=typer.colors.CYAN)
     typer.secho("     pip install -r requirements.txt", fg=typer.colors.CYAN)
     typer.echo()
     typer.secho("  3. Start the server:", fg=typer.colors.BRIGHT_WHITE)
-    typer.secho("     uvicorn app:app --reload --loop uvloop", fg=typer.colors.CYAN)
+    typer.secho("     tachyon run", fg=typer.colors.CYAN)
     typer.secho("     → API:   http://localhost:8000", fg=typer.colors.GREEN)
     typer.secho("     → Docs:  http://localhost:8000/docs", fg=typer.colors.GREEN)
     typer.echo()
     typer.secho("  4. Generate your first module:", fg=typer.colors.BRIGHT_WHITE)
     typer.secho("     tachyon g service users --crud", fg=typer.colors.CYAN)
-    typer.secho("     Then add it to app.py:", fg=typer.colors.BRIGHT_BLACK)
+    typer.secho("     Then register it in app.py:", fg=typer.colors.BRIGHT_BLACK)
     typer.secho("     from modules.users import router as users_router", fg=typer.colors.BRIGHT_BLACK)
     typer.secho("     app.include_router(users_router)", fg=typer.colors.BRIGHT_BLACK)
     typer.echo()

--- a/tachyon_api/cli/commands/routes.py
+++ b/tachyon_api/cli/commands/routes.py
@@ -1,0 +1,70 @@
+"""
+tachyon routes - List all registered routes in the app.
+"""
+
+import sys
+import typer
+from pathlib import Path
+
+
+def list_routes(app_path: str) -> None:
+    """Import the app and print all registered routes."""
+    # Add cwd to sys.path so local modules resolve
+    cwd = str(Path.cwd())
+    if cwd not in sys.path:
+        sys.path.insert(0, cwd)
+
+    # Parse "module:attribute" or bare "module"
+    if ":" in app_path:
+        module_str, attr = app_path.rsplit(":", 1)
+    else:
+        module_str, attr = app_path, "app"
+
+    try:
+        import importlib
+        module = importlib.import_module(module_str)
+    except ModuleNotFoundError as e:
+        typer.secho(f"❌ Module not found: {module_str}\n   {e}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    tachyon_app = getattr(module, attr, None)
+    if tachyon_app is None:
+        typer.secho(f"❌ Attribute '{attr}' not found in '{module_str}'", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    routes = getattr(tachyon_app, "routes", None)
+    if routes is None:
+        typer.secho("❌ Object doesn't look like a Tachyon app (no .routes attribute)", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    if not routes:
+        typer.secho("ℹ No routes registered.", fg=typer.colors.YELLOW)
+        return
+
+    # Column widths
+    method_w = 8
+    path_w   = max((len(r.get("path", "")) for r in routes), default=10) + 2
+
+    header = f"  {'METHOD':<{method_w}}  {'PATH':<{path_w}}  NAME"
+    typer.echo(f"\n{typer.style('Registered routes:', bold=True)}")
+    typer.echo("  " + "─" * (method_w + path_w + 20))
+    typer.echo(header)
+    typer.echo("  " + "─" * (method_w + path_w + 20))
+
+    METHOD_COLORS = {
+        "GET":    typer.colors.GREEN,
+        "POST":   typer.colors.BLUE,
+        "PUT":    typer.colors.YELLOW,
+        "PATCH":  typer.colors.CYAN,
+        "DELETE": typer.colors.RED,
+    }
+
+    for route in sorted(routes, key=lambda r: (r.get("path", ""), r.get("method", ""))):
+        method = route.get("method", "?").upper()
+        path   = route.get("path", "?")
+        name   = route.get("name", "")
+        color  = METHOD_COLORS.get(method, typer.colors.WHITE)
+        method_str = typer.style(f"{method:<{method_w}}", fg=color, bold=True)
+        typer.echo(f"  {method_str}  {path:<{path_w}}  {name}")
+
+    typer.echo(f"\n  {len(routes)} route(s) total.\n")

--- a/tachyon_api/cli/commands/run.py
+++ b/tachyon_api/cli/commands/run.py
@@ -1,0 +1,75 @@
+"""
+tachyon run - Start the development or production server.
+"""
+
+import sys
+import typer
+from pathlib import Path
+from typing import Optional
+
+
+def run_server(
+    app_path: str,
+    host: str,
+    port: int,
+    reload: bool,
+    workers: int,
+    prod: bool,
+    tachyon_server: bool,
+) -> None:
+    """Start uvicorn with sensible Tachyon defaults."""
+    try:
+        import uvicorn
+    except ImportError:
+        typer.secho("❌ uvicorn is not installed. Run: pip install uvicorn[standard]", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    # Resolve app path relative to cwd
+    if Path("app.py").exists() and ":" not in app_path:
+        app_path = f"{app_path}:{app_path}" if app_path != "app" else "app:app"
+
+    effective_workers = workers if (prod or workers > 1) else 1
+    effective_reload = reload and not prod
+
+    kwargs: dict = {
+        "app": app_path,
+        "host": host,
+        "port": port,
+        "workers": effective_workers,
+        "reload": effective_reload,
+        "access_log": not prod,
+    }
+
+    # Use uvloop + httptools when available
+    try:
+        import uvloop  # noqa: F401
+        kwargs["loop"] = "uvloop"
+    except ImportError:
+        pass
+    try:
+        import httptools  # noqa: F401
+        kwargs["http"] = "httptools"
+    except ImportError:
+        pass
+
+    # Use TachyonServer (F12b) when requested and available
+    if tachyon_server:
+        try:
+            from tachyon_api.server import TachyonHTTPProtocol
+            kwargs["http"] = TachyonHTTPProtocol
+            typer.secho("  ⚡ TachyonServer active (direct transport write)", fg=typer.colors.CYAN)
+        except ImportError:
+            typer.secho("  ℹ TachyonServer not available, using standard uvicorn", fg=typer.colors.BRIGHT_BLACK)
+
+    mode = "production" if prod else "development"
+    typer.echo(f"\n🚀 Starting Tachyon in {typer.style(mode, bold=True)} mode")
+    typer.echo(f"   App:    {app_path}")
+    typer.echo(f"   URL:    http://{host}:{port}")
+    if not prod:
+        typer.echo(f"   Docs:   http://{host}:{port}/docs")
+    typer.echo(f"   Reload: {'on' if effective_reload else 'off'}")
+    if effective_workers > 1:
+        typer.echo(f"   Workers: {effective_workers}")
+    typer.echo()
+
+    uvicorn.run(**kwargs)

--- a/tachyon_api/cli/main.py
+++ b/tachyon_api/cli/main.py
@@ -3,9 +3,12 @@ Tachyon CLI - Main entry point
 
 Commands:
 - tachyon new <project>     Create new project
+- tachyon run [app]         Start development / production server
 - tachyon generate          Generate components (alias: g)
+- tachyon routes [app]      List all registered routes
 - tachyon openapi           OpenAPI utilities
 - tachyon lint              Code quality (ruff wrapper)
+- tachyon version           Show version
 """
 
 import typer
@@ -21,24 +24,18 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
-# Register sub-commands
-app.add_typer(
-    generate.app,
-    name="generate",
-    help="Generate components (service, controller, etc.)",
-)
-app.add_typer(generate.app, name="g", help="Alias for 'generate'", hidden=True)
-app.add_typer(openapi.app, name="openapi", help="OpenAPI schema utilities")
-app.add_typer(lint.app, name="lint", help="Code quality tools (ruff wrapper)")
+# Sub-command groups
+app.add_typer(generate.app, name="generate", help="Generate components (service, controller, etc.)")
+app.add_typer(generate.app, name="g",        help="Alias for 'generate'", hidden=True)
+app.add_typer(openapi.app,  name="openapi",  help="OpenAPI schema utilities")
+app.add_typer(lint.app,     name="lint",     help="Code quality tools (ruff wrapper)")
 
 
 @app.command()
 def new(
-    name: str = typer.Argument(..., help="Project name"),
+    name: str = typer.Argument(..., help="Project name (e.g. my-api)"),
     path: Optional[Path] = typer.Option(
-        None,
-        "--path",
-        "-p",
+        None, "--path", "-p",
         help="Parent directory for the project (default: current directory)",
     ),
 ):
@@ -50,8 +47,50 @@ def new(
         tachyon new my-api --path ./projects
     """
     from .commands.new import create_project
-
     create_project(name, path)
+
+
+@app.command()
+def run(
+    app_path: str = typer.Argument("app:app", help="ASGI app in 'module:attribute' format"),
+    host: str   = typer.Option("0.0.0.0", "--host", "-h", help="Bind host"),
+    port: int   = typer.Option(8000,      "--port", "-p", help="Bind port"),
+    reload: bool = typer.Option(True,  "--reload/--no-reload", help="Auto-reload on code changes"),
+    workers: int = typer.Option(1,     "--workers", "-w", help="Number of worker processes"),
+    prod: bool   = typer.Option(False, "--prod",           help="Production mode (no reload, workers=4)"),
+    tachyon_server: bool = typer.Option(
+        False, "--tachyon-server",
+        help="Use TachyonServer for direct transport writes (F12b)",
+    ),
+):
+    """
+    ▶  Start the Tachyon development or production server.
+
+    Wraps uvicorn with sensible defaults (uvloop, httptools, reload in dev).
+
+    Example:
+        tachyon run
+        tachyon run app:app --port 9000
+        tachyon run --prod --workers 4
+        tachyon run --tachyon-server
+    """
+    from .commands.run import run_server
+    run_server(app_path, host, port, reload, workers, prod, tachyon_server)
+
+
+@app.command()
+def routes(
+    app_path: str = typer.Argument("app:app", help="ASGI app in 'module:attribute' format"),
+):
+    """
+    📋 List all registered routes without starting the server.
+
+    Example:
+        tachyon routes
+        tachyon routes myapp:app
+    """
+    from .commands.routes import list_routes
+    list_routes(app_path)
 
 
 @app.command()

--- a/tachyon_api/cli/templates/project.py
+++ b/tachyon_api/cli/templates/project.py
@@ -47,24 +47,42 @@ if __name__ == "__main__":
     )
 '''
 
+    ENV_EXAMPLE = """# Application
+APP_NAME=Tachyon API
+VERSION=0.1.0
+DEBUG=true
+
+# Server
+HOST=0.0.0.0
+PORT=8000
+
+# Database (uncomment and configure when ready)
+# DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+"""
+
     CONFIG = '''"""
-Application configuration.
+Application configuration — reads from environment / .env file.
 """
 
 import os
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass  # python-dotenv optional; set env vars directly in production
 
 
 class Settings:
     """Application settings loaded from environment variables."""
-    
+
     APP_NAME: str = os.getenv("APP_NAME", "Tachyon API")
-    VERSION: str = os.getenv("VERSION", "0.1.0")
-    DEBUG: bool = os.getenv("DEBUG", "true").lower() == "true"
-    
+    VERSION:  str = os.getenv("VERSION",  "0.1.0")
+    DEBUG:    bool = os.getenv("DEBUG", "true").lower() == "true"
+
     # Server
     HOST: str = os.getenv("HOST", "0.0.0.0")
     PORT: int = int(os.getenv("PORT", "8000"))
-    
+
     # Database (example)
     # DATABASE_URL: str = os.getenv("DATABASE_URL", "sqlite:///./app.db")
 
@@ -77,6 +95,9 @@ tachyon-api>=1.2.0
 
 # Server
 uvicorn[standard]>=0.35.0
+
+# Configuration
+python-dotenv>=1.0.0
 
 # Development
 pytest>=8.0.0

--- a/tachyon_api/cli/templates/service.py
+++ b/tachyon_api/cli/templates/service.py
@@ -322,10 +322,61 @@ class Test{class_name}Service:
         """Placeholder test - implement your tests here."""
         # TODO: Implement actual tests
         # from modules.{snake_name} import {class_name}Service, {class_name}Repository
-        # 
+        #
         # repository = {class_name}Repository()
         # service = {class_name}Service(repository)
         # result = service.get_all()
         # assert result is not None
         assert True
+'''
+
+    @staticmethod
+    def middleware(snake_name: str, class_name: str) -> str:
+        return f'''"""
+{class_name}Middleware — ASGI middleware skeleton.
+
+Register in app.py:
+    app.add_middleware({class_name}Middleware)
+"""
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+class {class_name}Middleware:
+    """
+    {class_name} ASGI middleware.
+
+    Wraps every HTTP request. Override the process() method with your logic.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope, receive)
+        response = await self.process(request)
+        if response is not None:
+            # Short-circuit: return early (e.g. auth rejection)
+            await response(scope, receive, send)
+            return
+
+        await self.app(scope, receive, send)
+
+    async def process(self, request: Request) -> Response | None:
+        """
+        Inspect / modify the request before it reaches the endpoint.
+
+        Return a Response to short-circuit (e.g. 401), or None to continue.
+        """
+        # TODO: implement your middleware logic here
+        # Example — reject unauthenticated requests:
+        # if not request.headers.get("authorization"):
+        #     return Response("Unauthorized", status_code=401)
+        return None
 '''


### PR DESCRIPTION
## 6 CLI improvements

### 1. `tachyon run` — start server with one command
```bash
tachyon run                     # dev: reload on, uvloop+httptools auto
tachyon run --prod --workers 4  # production mode
tachyon run --port 9000
tachyon run --tachyon-server    # F12b direct transport writes
```

### 2. `tachyon routes` — list routes without starting the server
```bash
tachyon routes          # reads app:app
tachyon routes myapp:app
```
Colour-coded by HTTP method (GET=green, POST=blue, DELETE=red, etc.)

### 3. `tachyon generate middleware <name>` — ASGI middleware skeleton
```bash
tachyon g middleware auth
tachyon g middleware rate_limit
```
Generates an annotated `AuthMiddleware` with `__call__` + `process()` hook.

### 4. `.env.example` + dotenv in `tachyon new`
- Creates `.env.example` with all config variables pre-filled
- `config.py` now imports `python-dotenv` (graceful fallback if missing)
- `requirements.txt` includes `python-dotenv>=1.0.0`
- Post-gen step 2 says `cp .env.example .env`

### 5. Name validation (`tachyon new` and `tachyon generate`)
- `tachyon new for` → ❌ Python reserved keyword
- `tachyon new my-api` → ✅ normalised to `my_api`
- `tachyon g service 123bad` → ❌ starts with digit
- `tachyon g middleware rate-limit` → ✅ normalised to `rate_limit`

### 6. `repo` alias hidden from `--help`
`tachyon g repo` still works, but no longer clutters `generate --help` with a duplicate entry.