### PR TITLE
feat(cli): tachyon install-skill — AI context for all major coding assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,19 @@ tachyon lint all
 
 **Name validation:** hyphens auto-converted to underscores (`my-api` → `my_api`), Python keywords rejected with a clear error.
 
+### AI Agent Integration
+
+Teach your AI coding assistant (Claude Code, Cursor, Copilot, OpenCode, Codex) how to write correct Tachyon code:
+
+```bash
+tachyon install-skill              # generates context files for all tools
+tachyon install-skill --cursor     # only .cursorrules
+tachyon install-skill --claude     # only CLAUDE.md
+tachyon install-skill --copilot    # only .github/copilot-instructions.md
+```
+
+Installs knowledge about `Body()` requirement, `Struct` vs BaseModel, DI patterns, CLI commands, and anti-patterns. Safe to run multiple times.
+
 👉 [Full CLI documentation](./docs/12-cli.md)
 
 ---

--- a/docs/12-cli.md
+++ b/docs/12-cli.md
@@ -338,6 +338,41 @@ print(settings.APP_NAME)  # reads from .env or environment
 
 ---
 
+---
+
+## 🤖 tachyon install-skill
+
+Install Tachyon context files so your AI coding assistant understands how to write
+correct Tachyon code — `Body()` requirement, `Struct` vs BaseModel, DI patterns,
+CLI commands, and anti-patterns.
+
+```bash
+tachyon install-skill              # installs for all tools
+tachyon install-skill --cursor     # only .cursorrules
+tachyon install-skill --claude     # only CLAUDE.md
+tachyon install-skill --copilot    # only .github/copilot-instructions.md
+tachyon install-skill --opencode   # only .opencode/rules.md
+tachyon install-skill --agents     # only AGENTS.md (Codex, Aider, generic)
+```
+
+### What it generates
+
+| Tool | File |
+|------|------|
+| **Cursor** | `.cursorrules` |
+| **Claude Code** | `CLAUDE.md` (creates or appends Tachyon section) |
+| **GitHub Copilot** | `.github/copilot-instructions.md` |
+| **OpenCode** | `.opencode/rules.md` |
+| **Codex / Aider / generic** | `AGENTS.md` |
+
+All files contain the same knowledge base: syntax reference, correct patterns,
+anti-patterns, and CLI commands. Safe to run multiple times — idempotent.
+
+> **Tip:** Run `tachyon install-skill` in the root of any project that uses Tachyon
+> to give your AI assistant full context immediately.
+
+---
+
 ## 🔗 Related
 
 - [Architecture](./02-architecture.md) — clean architecture patterns

--- a/tachyon_api/cli/commands/skill.py
+++ b/tachyon_api/cli/commands/skill.py
@@ -1,0 +1,91 @@
+"""
+tachyon install-skill - Install Tachyon AI context for coding assistants.
+
+Generates the appropriate context/rules files so AI agents (Claude Code,
+Cursor, GitHub Copilot, OpenCode, Codex, etc.) understand how to write
+correct Tachyon API code.
+"""
+
+import typer
+from pathlib import Path
+
+from ..templates.ai_skill import (
+    cursor_rules,
+    claude_md_snippet,
+    copilot_instructions,
+    opencode_rules,
+    agents_md,
+)
+
+
+def _write(path: Path, content: str, label: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existed = path.exists()
+    if existed and path.read_text() == content:
+        typer.secho(f"  ✓ {label} — already up to date", fg=typer.colors.BRIGHT_BLACK)
+        return
+    path.write_text(content)
+    verb = "Updated" if existed else "Created"
+    typer.secho(f"  📄 {verb} {label}", fg=typer.colors.GREEN)
+
+
+def install_skill(
+    cursor: bool,
+    claude: bool,
+    copilot: bool,
+    opencode: bool,
+    agents: bool,
+    all_tools: bool,
+    output_dir: Path,
+) -> None:
+    do_all = all_tools or not any([cursor, claude, copilot, opencode, agents])
+
+    typer.echo(f"\n🤖 Installing Tachyon AI skill in: {typer.style(str(output_dir), bold=True)}\n")
+
+    if do_all or cursor:
+        _write(
+            output_dir / ".cursorrules",
+            cursor_rules(),
+            ".cursorrules  (Cursor AI)",
+        )
+
+    if do_all or claude:
+        target = output_dir / "CLAUDE.md"
+        if target.exists():
+            # Append the snippet if CLAUDE.md already exists and doesn't have Tachyon section
+            existing = target.read_text()
+            if "Tachyon API — Project Context" not in existing:
+                target.write_text(existing.rstrip() + "\n\n---\n\n" + claude_md_snippet())
+                typer.secho(f"  📄 Appended Tachyon section to CLAUDE.md  (Claude Code)", fg=typer.colors.GREEN)
+            else:
+                typer.secho(f"  ✓ CLAUDE.md already contains Tachyon context", fg=typer.colors.BRIGHT_BLACK)
+        else:
+            _write(target, claude_md_snippet(), "CLAUDE.md  (Claude Code)")
+
+    if do_all or copilot:
+        _write(
+            output_dir / ".github" / "copilot-instructions.md",
+            copilot_instructions(),
+            ".github/copilot-instructions.md  (GitHub Copilot)",
+        )
+
+    if do_all or opencode:
+        _write(
+            output_dir / ".opencode" / "rules.md",
+            opencode_rules(),
+            ".opencode/rules.md  (OpenCode)",
+        )
+
+    if do_all or agents:
+        _write(
+            output_dir / "AGENTS.md",
+            agents_md(),
+            "AGENTS.md  (Codex / Aider / generic agents)",
+        )
+
+    typer.echo(f"\n✅ Done! The AI context files teach your assistant:\n")
+    typer.secho("   • Tachyon syntax and key differences from FastAPI", fg=typer.colors.CYAN)
+    typer.secho("   • Body() requirement, Struct usage, DI patterns", fg=typer.colors.CYAN)
+    typer.secho("   • CLI commands (tachyon run, generate, routes, ...)", fg=typer.colors.CYAN)
+    typer.secho("   • Common anti-patterns to avoid", fg=typer.colors.CYAN)
+    typer.echo()

--- a/tachyon_api/cli/main.py
+++ b/tachyon_api/cli/main.py
@@ -93,6 +93,33 @@ def routes(
     list_routes(app_path)
 
 
+@app.command("install-skill")
+def install_skill(
+    cursor:   bool = typer.Option(False, "--cursor",   help="Install for Cursor (.cursorrules)"),
+    claude:   bool = typer.Option(False, "--claude",   help="Install for Claude Code (CLAUDE.md)"),
+    copilot:  bool = typer.Option(False, "--copilot",  help="Install for GitHub Copilot (.github/copilot-instructions.md)"),
+    opencode: bool = typer.Option(False, "--opencode", help="Install for OpenCode (.opencode/rules.md)"),
+    agents:   bool = typer.Option(False, "--agents",   help="Install generic AGENTS.md (Codex, Aider, etc.)"),
+    all_tools: bool = typer.Option(False, "--all",     help="Install for all tools (default when no flag given)"),
+    path: Optional[Path] = typer.Option(None, "--path", "-p", help="Target directory (default: current directory)"),
+):
+    """
+    🤖 Install Tachyon AI context for your coding assistant.
+
+    Generates rules/instructions files so AI agents understand Tachyon syntax,
+    patterns, and best practices (Body() requirement, Struct vs BaseModel, DI, CLI, etc.).
+
+    Example:
+        tachyon install-skill              # installs all tools
+        tachyon install-skill --cursor     # only .cursorrules
+        tachyon install-skill --claude     # only CLAUDE.md
+        tachyon install-skill --copilot    # only .github/copilot-instructions.md
+        tachyon install-skill --all        # explicit all
+    """
+    from .commands.skill import install_skill as _install
+    _install(cursor, claude, copilot, opencode, agents, all_tools, path or Path.cwd())
+
+
 @app.command()
 def version():
     """Show Tachyon version."""

--- a/tachyon_api/cli/templates/__init__.py
+++ b/tachyon_api/cli/templates/__init__.py
@@ -4,5 +4,14 @@ CLI Templates for code generation.
 
 from .project import ProjectTemplates
 from .service import ServiceTemplates
+from .ai_skill import cursor_rules, claude_md_snippet, copilot_instructions, opencode_rules, agents_md
 
-__all__ = ["ProjectTemplates", "ServiceTemplates"]
+__all__ = [
+    "ProjectTemplates",
+    "ServiceTemplates",
+    "cursor_rules",
+    "claude_md_snippet",
+    "copilot_instructions",
+    "opencode_rules",
+    "agents_md",
+]

--- a/tachyon_api/cli/templates/ai_skill.py
+++ b/tachyon_api/cli/templates/ai_skill.py
@@ -1,0 +1,354 @@
+"""
+AI skill / rules content for Tachyon API.
+
+This is the canonical knowledge base injected into each AI tool's context file.
+"""
+
+# ── Core content (all tools share this) ──────────────────────────────────────
+
+_HEADER = "# Tachyon API — AI Context"
+
+_OVERVIEW = """\
+Tachyon API is a high-performance Python web framework with FastAPI-compatible syntax,
+built on Starlette + msgspec + orjson. It is NOT a wrapper of FastAPI — it is an
+independent implementation with a different internal architecture.
+
+Key differences from FastAPI:
+- Uses `msgspec.Struct` instead of Pydantic BaseModel for validation (faster, different API)
+- Body parameters REQUIRE `= Body()` marker — not just a type annotation
+- `@injectable` for singleton services, `Depends()` for callable/class DI
+- `tachyon_api.Struct` is re-exported from msgspec — use it everywhere instead of BaseModel
+- Router uses `app.include_router(router)` just like FastAPI
+- No automatic coercion of query params — use `Query(default)` explicitly
+"""
+
+_INSTALLATION = """\
+## Installation
+
+```bash
+pip install tachyon-api
+uvicorn app:app --reload --loop uvloop  # or: tachyon run
+```
+"""
+
+_QUICK_REFERENCE = """\
+## Quick Reference
+
+### Imports
+```python
+from tachyon_api import Tachyon, Struct, Body, Query, Path, Header, Cookie
+from tachyon_api import Router, Depends, injectable, HTTPException
+from tachyon_api.security import HTTPBearer, OAuth2PasswordBearer
+from tachyon_api.background import BackgroundTasks
+```
+
+### Basic app
+```python
+from tachyon_api import Tachyon
+app = Tachyon()
+
+@app.get("/")
+def root():
+    return {"status": "ok"}
+```
+
+### Models — use Struct, NOT BaseModel
+```python
+from tachyon_api import Struct
+
+class User(Struct):
+    name: str
+    email: str
+    age: int = 0  # default values work
+
+class UserResponse(Struct):
+    id: str
+    name: str
+    email: str
+```
+
+### Parameters
+```python
+# Path param (implicit — name must match {path_param} in route)
+@app.get("/users/{user_id}")
+def get_user(user_id: int):
+    ...
+
+# Query param
+@app.get("/users")
+def list_users(skip: int = Query(0), limit: int = Query(100)):
+    ...
+
+# Body — ALWAYS use Body() for POST/PUT/PATCH body params
+@app.post("/users")
+def create_user(user: User = Body()):  # ← Body() is REQUIRED
+    ...
+
+# Header
+@app.get("/auth")
+def auth(x_api_key: str = Header(...)):
+    ...
+```
+
+### Dependency Injection
+```python
+from tachyon_api import injectable, Depends
+
+@injectable
+class UserService:
+    def get(self, id: str): return {"id": id}
+
+# Implicit (annotated param that's @injectable)
+@app.get("/users/{id}")
+def get_user(id: str, svc: UserService):  # svc injected automatically
+    return svc.get(id)
+
+# Explicit
+@app.get("/users/{id}")
+def get_user(id: str, svc: UserService = Depends()):
+    return svc.get(id)
+```
+
+### Routers
+```python
+from tachyon_api import Router
+
+router = Router(prefix="/users", tags=["Users"])
+
+@router.get("/")
+def list_users(): ...
+
+# In app.py
+app.include_router(router)
+```
+
+### Error handling
+```python
+from tachyon_api import HTTPException
+
+raise HTTPException(status_code=404, detail="User not found")
+raise HTTPException(status_code=422, detail="Validation failed")
+```
+
+### Response model
+```python
+@app.get("/users/{id}", response_model=UserResponse)
+def get_user(id: str):
+    return UserResponse(id=id, name="Alice", email="alice@example.com")
+```
+"""
+
+_PATTERNS = """\
+## Common Patterns
+
+### CRUD endpoint set
+```python
+from typing import List
+from tachyon_api import Router, Depends, Body, Query
+from tachyon_api import injectable, HTTPException, Struct
+
+class Item(Struct):
+    name: str
+    price: float
+
+class ItemResponse(Struct):
+    id: str
+    name: str
+    price: float
+
+@injectable
+class ItemService:
+    def __init__(self):
+        self._store: dict = {}
+
+    def list(self, skip=0, limit=100):
+        return list(self._store.values())[skip:skip+limit]
+
+    def get(self, id: str):
+        item = self._store.get(id)
+        if not item:
+            raise HTTPException(404, "Item not found")
+        return item
+
+    def create(self, data: Item) -> dict:
+        import uuid, msgspec
+        id = str(uuid.uuid4())
+        item = {"id": id, **msgspec.structs.asdict(data)}
+        self._store[id] = item
+        return item
+
+router = Router(prefix="/items", tags=["Items"])
+
+@router.get("/", response_model=List[ItemResponse])
+def list_items(skip: int = Query(0), limit: int = Query(100), svc: ItemService = Depends()):
+    return svc.list(skip, limit)
+
+@router.get("/{id}", response_model=ItemResponse)
+def get_item(id: str, svc: ItemService = Depends()):
+    return svc.get(id)
+
+@router.post("/", response_model=ItemResponse)
+def create_item(data: Item = Body(), svc: ItemService = Depends()):
+    return svc.create(data)
+```
+
+### Authentication with Bearer token
+```python
+from tachyon_api.security import HTTPBearer
+
+bearer = HTTPBearer()
+
+@app.get("/me")
+async def me(credentials = Depends(bearer)):
+    token = credentials.credentials  # the raw JWT string
+    # validate token here
+    return {"token": token}
+```
+
+### Background tasks
+```python
+from tachyon_api.background import BackgroundTasks
+
+@app.post("/notify")
+async def notify(msg: str = Query(...), bg: BackgroundTasks = None):
+    async def send_email():
+        await asyncio.sleep(1)
+        print(f"Sent: {msg}")
+    bg.add_task(send_email)
+    return {"queued": True}
+```
+"""
+
+_ANTIPATTERNS = """\
+## Anti-patterns to avoid
+
+```python
+# ❌ WRONG — Body param without Body() — will be treated as query param
+@app.post("/users")
+def create_user(user: User):  # broken
+    ...
+
+# ✅ CORRECT
+@app.post("/users")
+def create_user(user: User = Body()):
+    ...
+
+# ❌ WRONG — using Pydantic BaseModel
+from pydantic import BaseModel
+class User(BaseModel): ...  # won't integrate with Tachyon serialization
+
+# ✅ CORRECT
+from tachyon_api import Struct
+class User(Struct): ...
+
+# ❌ WRONG — data.__dict__ on a Struct (no __dict__)
+item = {"id": id, **data.__dict__}  # AttributeError
+
+# ✅ CORRECT
+import msgspec
+item = {"id": id, **msgspec.structs.asdict(data)}
+
+# ❌ WRONG — async exception handlers (will block event loop)
+@app.exception_handler(HTTPException)
+async def handler(request, exc): ...  # sync is correct
+
+# ✅ CORRECT
+@app.exception_handler(HTTPException)
+def handler(request, exc): ...
+```
+"""
+
+_CLI_REFERENCE = """\
+## CLI Reference
+
+```bash
+tachyon new my-api              # create project
+tachyon run                     # start dev server (reload on, uvloop auto)
+tachyon run --prod --workers 4  # production
+tachyon routes                  # list all routes
+tachyon g service users --crud  # generate full CRUD module
+tachyon g middleware auth       # generate ASGI middleware
+tachyon lint all                # lint + format
+tachyon version                 # show version
+```
+
+Generated service structure:
+```
+modules/users/
+├── users_controller.py   # Router with endpoints
+├── users_service.py      # @injectable business logic
+├── users_repository.py   # data access
+├── users_dto.py          # Struct models
+└── tests/
+```
+"""
+
+_FOOTER = """\
+---
+Full docs: https://github.com/jmpanozzoz/tachyon_api
+"""
+
+
+# ── Tool-specific wrappers ────────────────────────────────────────────────────
+
+def _full_content() -> str:
+    return "\n\n".join([
+        _HEADER,
+        _OVERVIEW.strip(),
+        _INSTALLATION.strip(),
+        _QUICK_REFERENCE.strip(),
+        _PATTERNS.strip(),
+        _ANTIPATTERNS.strip(),
+        _CLI_REFERENCE.strip(),
+        _FOOTER.strip(),
+    ])
+
+
+def cursor_rules() -> str:
+    """Content for .cursorrules"""
+    return f"""\
+{_HEADER}
+
+You are an expert Tachyon API developer. Always follow these rules when working
+with Tachyon API projects.
+
+{_OVERVIEW.strip()}
+
+{_QUICK_REFERENCE.strip()}
+
+{_ANTIPATTERNS.strip()}
+
+{_CLI_REFERENCE.strip()}
+"""
+
+
+def claude_md_snippet() -> str:
+    """Snippet to append to CLAUDE.md (or use as standalone)"""
+    return f"""\
+# Tachyon API — Project Context
+
+This project uses **Tachyon API** — a high-performance FastAPI-alternative framework.
+
+{_OVERVIEW.strip()}
+
+{_QUICK_REFERENCE.strip()}
+
+{_ANTIPATTERNS.strip()}
+
+{_CLI_REFERENCE.strip()}
+"""
+
+
+def copilot_instructions() -> str:
+    """Content for .github/copilot-instructions.md"""
+    return _full_content()
+
+
+def opencode_rules() -> str:
+    """Content for .opencode/rules.md"""
+    return _full_content()
+
+
+def agents_md() -> str:
+    """Content for AGENTS.md (generic — works with Codex, Aider, etc.)"""
+    return _full_content()


### PR DESCRIPTION
## `tachyon install-skill`

New CLI command that installs Tachyon knowledge into your AI coding assistant's context files.

```bash
tachyon install-skill              # all tools
tachyon install-skill --cursor     # .cursorrules
tachyon install-skill --claude     # CLAUDE.md (creates or appends)
tachyon install-skill --copilot    # .github/copilot-instructions.md
tachyon install-skill --opencode   # .opencode/rules.md
tachyon install-skill --agents     # AGENTS.md
tachyon install-skill --path ./my-project  # custom directory
```

### Knowledge installed

The generated files teach the AI agent:
- Tachyon vs FastAPI: key differences and why they matter
- `Body()` is REQUIRED for POST/PUT body params (most common mistake)
- Use `msgspec.Struct`, not Pydantic `BaseModel`
- Use `msgspec.structs.asdict(data)`, not `data.__dict__`
- `@injectable` for singletons, `Depends()` for class/callable DI
- CLI reference: `tachyon run`, `tachyon routes`, `tachyon g service --crud`, etc.
- Anti-patterns with concrete before/after examples

### Files generated

| Tool | File |
|------|------|
| Cursor | `.cursorrules` |
| Claude Code | `CLAUDE.md` (appends section if file already exists) |
| GitHub Copilot | `.github/copilot-instructions.md` |
| OpenCode | `.opencode/rules.md` |
| Codex / Aider | `AGENTS.md` |

### Idempotent

Running `tachyon install-skill` twice is safe — existing files are updated, not duplicated. CLAUDE.md specifically checks for the Tachyon section before appending.

### Tests
All 4 skill smoke tests pass (install all, idempotent, CLAUDE.md append).