### PR TITLE
fix(high): security headers middleware, null bytes, cache clear, msgspec skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`responses.py`** — `response_validation_error_response` no longer echoes internal error details in the HTTP response body; details are logged at WARNING level only.
 - **`middlewares/cors.py`** — `CORSMiddleware` defaults changed to `allow_origins=()` and `allow_headers=()`; `allow_methods` defaults to explicit safe verbs instead of `"*"`. CORS is now opt-in — callers must list origins explicitly.
 - **`security.py`** — `APIKeyQuery` docstring warns that query-parameter tokens appear in server logs, browser history, and Referer headers.
+- **`middlewares/security_headers.py`** — New `SecurityHeadersMiddleware`: opt-in middleware that injects `x-content-type-options`, `x-frame-options`, `referrer-policy`, and `x-permitted-cross-domain-policies` on every HTTP response. HSTS and CSP available via constructor params.
+- **`processing/parameters.py`** — Path parameters containing null bytes (`\x00`) are rejected with 422 before type conversion.
 
 ### Fixed
 
 - **`background.py`** — `BackgroundTasks.run_tasks()` no longer swallows task exceptions silently; failures are logged at WARNING with full traceback (`exc_info=True`).
 - **`core/lifecycle.py`** — Startup handlers now raise `RuntimeError` on failure (with the original exception as cause), preventing the app from booting in a broken state. Shutdown handlers log failures at WARNING and continue processing remaining handlers.
+- **`cache.py`** — `RedisCacheBackend.clear()` now calls `flushdb()` (current DB only) instead of silently no-oping. Falls back to `flushall()` if `flushdb()` is unavailable.
+
+### Performance
+
+- **`processing/response_processor.py`** — `msgspec.convert()` is skipped when `type(payload) is response_model`, avoiding a C-level conversion call for endpoints that already return the correct type.
 
 ### Performance
 

--- a/tachyon_api/cache.py
+++ b/tachyon_api/cache.py
@@ -230,8 +230,15 @@ class RedisCacheBackend(BaseCacheBackend):
             pass
 
     def clear(self) -> None:
-        # Not standardized; no-op by default
-        pass
+        # flushdb() clears the current Redis database only (not all databases).
+        # Use with care in shared Redis instances.
+        try:
+            self.client.flushdb()
+        except Exception:
+            try:
+                self.client.flushall()
+            except Exception:
+                pass
 
 
 class MemcachedCacheBackend(BaseCacheBackend):

--- a/tachyon_api/middlewares/__init__.py
+++ b/tachyon_api/middlewares/__init__.py
@@ -1,4 +1,5 @@
 from .cors import CORSMiddleware
 from .logger import LoggerMiddleware
+from .security_headers import SecurityHeadersMiddleware
 
-__all__ = ["CORSMiddleware", "LoggerMiddleware"]
+__all__ = ["CORSMiddleware", "LoggerMiddleware", "SecurityHeadersMiddleware"]

--- a/tachyon_api/middlewares/security_headers.py
+++ b/tachyon_api/middlewares/security_headers.py
@@ -1,0 +1,80 @@
+from typing import Iterable, Optional, Tuple
+
+
+_DEFAULT_HEADERS: Tuple[Tuple[str, str], ...] = (
+    ("x-content-type-options", "nosniff"),
+    ("x-frame-options", "DENY"),
+    ("referrer-policy", "strict-origin-when-cross-origin"),
+    ("x-permitted-cross-domain-policies", "none"),
+)
+
+
+class SecurityHeadersMiddleware:
+    """Injects security response headers on every HTTP response.
+
+    All headers are opt-in overridable at construction time. Pass ``None`` for
+    any header to remove it from the response entirely.
+
+    Default values:
+    - ``x-content-type-options: nosniff``   — prevents MIME sniffing
+    - ``x-frame-options: DENY``             — prevents clickjacking
+    - ``referrer-policy: strict-origin-when-cross-origin``
+    - ``x-permitted-cross-domain-policies: none``
+
+    HSTS and CSP are *not* included by default because they require site-specific
+    configuration to avoid breaking TLS setups or content loading. Pass them
+    explicitly if needed.
+
+    Example::
+
+        app.add_middleware(
+            SecurityHeadersMiddleware,
+            hsts="max-age=63072000; includeSubDomains",
+            csp="default-src 'self'",
+        )
+    """
+
+    def __init__(
+        self,
+        app,
+        x_content_type_options: Optional[str] = "nosniff",
+        x_frame_options: Optional[str] = "DENY",
+        referrer_policy: Optional[str] = "strict-origin-when-cross-origin",
+        x_permitted_cross_domain_policies: Optional[str] = "none",
+        hsts: Optional[str] = None,
+        csp: Optional[str] = None,
+        extra_headers: Optional[Iterable[Tuple[str, str]]] = None,
+    ):
+        self.app = app
+        raw: list[Tuple[bytes, bytes]] = []
+        for header_name, value in (
+            ("x-content-type-options", x_content_type_options),
+            ("x-frame-options", x_frame_options),
+            ("referrer-policy", referrer_policy),
+            ("x-permitted-cross-domain-policies", x_permitted_cross_domain_policies),
+            ("strict-transport-security", hsts),
+            ("content-security-policy", csp),
+        ):
+            if value is not None:
+                raw.append((header_name.encode(), value.encode()))
+        if extra_headers:
+            for name, val in extra_headers:
+                raw.append((name.lower().encode(), val.encode()))
+        # Pre-encode once at startup; list is copied per-response to avoid ASGI
+        # middlewares mutating a shared reference.
+        self._headers: list[Tuple[bytes, bytes]] = raw
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") != "http" or not self._headers:
+            return await self.app(scope, receive, send)
+
+        _headers = self._headers
+
+        async def send_wrapper(message):
+            if message.get("type") == "http.response.start":
+                headers = list(message.get("headers", []) or [])
+                headers.extend(_headers)
+                message = {**message, "headers": headers}
+            return await send(message)
+
+        return await self.app(scope, receive, send_wrapper)

--- a/tachyon_api/processing/parameters.py
+++ b/tachyon_api/processing/parameters.py
@@ -252,6 +252,8 @@ class ParameterProcessor:
             return None, None
 
         value_str = path_params[name]
+        if "\x00" in value_str:
+            return None, validation_error_response(f"Invalid path parameter: {name}")
 
         if p.is_list:
             parts = value_str.split(",") if value_str else []

--- a/tachyon_api/processing/response_processor.py
+++ b/tachyon_api/processing/response_processor.py
@@ -26,7 +26,7 @@ class ResponseProcessor:
         if isinstance(payload, Response):
             return payload
 
-        if response_model is not None:
+        if response_model is not None and type(payload) is not response_model:
             try:
                 payload = msgspec.convert(payload, response_model)
             except Exception as e:


### PR DESCRIPTION
## Summary

- **`middlewares/security_headers.py`** (nuevo): `SecurityHeadersMiddleware` opt-in — inyecta `x-content-type-options`, `x-frame-options`, `referrer-policy`, `x-permitted-cross-domain-policies`. HSTS y CSP disponibles via constructor. Headers pre-encoded en startup, lista copiada por response (seguro con middlewares que mutan `message["headers"]`)
- **`processing/parameters.py`**: path params con null bytes (`\x00`) se rechazan con 422 antes de la type conversion
- **`cache.py`**: `RedisCacheBackend.clear()` implementa `flushdb()` (solo DB actual) en vez de no-op silencioso; fallback a `flushall()` si no disponible
- **`processing/response_processor.py`**: `msgspec.convert()` se saltea cuando `type(payload) is response_model` — evita call C innecesario para endpoints que ya devuelven el tipo correcto

## Test plan

- [ ] 24/25 tests pasan (fallo pre-existente en `test_new_creates_project_structure` no relacionado)
- [ ] Verificar que `SecurityHeadersMiddleware` agrega headers en cada response HTTP
- [ ] Verificar que path params con `\x00` devuelven 422
- [ ] Verificar que `RedisCacheBackend.clear()` llama `flushdb()` en cliente mock