### PR TITLE
feat(testing): create_client in tachyon_api/testing + httpx kwargs

### DIFF
--- a/tachyon_api/testing.py
+++ b/tachyon_api/testing.py
@@ -1,6 +1,8 @@
 """Sync and async test clients for Tachyon applications."""
 
-from typing import Optional
+from contextlib import asynccontextmanager
+from typing import Any, Dict, Optional
+
 from starlette.testclient import TestClient
 from httpx import AsyncClient, ASGITransport
 
@@ -24,22 +26,90 @@ class TachyonTestClient(TestClient):
 
 
 class AsyncTachyonTestClient:
-    """Async test client wrapping httpx.AsyncClient with ASGITransport."""
+    """Async context-manager wrapping httpx.AsyncClient with ASGITransport.
 
-    def __init__(self, app, base_url: str = "http://test", **kwargs):
+    Yields the underlying ``httpx.AsyncClient`` so all httpx features
+    (cookies, auth, custom headers, follow_redirects, timeout, etc.) are
+    available via constructor kwargs.
+
+    Example::
+
+        async with AsyncTachyonTestClient(app, headers={"X-Token": "test"}) as client:
+            r = await client.get("/users/1")
+    """
+
+    def __init__(
+        self,
+        app,
+        base_url: str = "http://testserver",
+        headers: Optional[Dict[str, str]] = None,
+        cookies: Optional[Dict[str, str]] = None,
+        auth: Any = None,
+        follow_redirects: bool = False,
+        timeout: float = 5.0,
+        **kwargs,
+    ):
         self._app = app
-        self._base_url = base_url
-        self._kwargs = kwargs
+        self._client_kwargs: Dict[str, Any] = {
+            "transport": ASGITransport(app=app),
+            "base_url": base_url,
+            "follow_redirects": follow_redirects,
+            "timeout": timeout,
+            **kwargs,
+        }
+        if headers:
+            self._client_kwargs["headers"] = headers
+        if cookies:
+            self._client_kwargs["cookies"] = cookies
+        if auth is not None:
+            self._client_kwargs["auth"] = auth
         self._client: Optional[AsyncClient] = None
 
     async def __aenter__(self) -> AsyncClient:
-        self._client = AsyncClient(
-            transport=ASGITransport(app=self._app),
-            base_url=self._base_url,
-            **self._kwargs,
-        )
+        self._client = AsyncClient(**self._client_kwargs)
         return self._client
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self._client:
             await self._client.aclose()
+
+
+@asynccontextmanager
+async def create_client(
+    app,
+    base_url: str = "http://testserver",
+    headers: Optional[Dict[str, str]] = None,
+    cookies: Optional[Dict[str, str]] = None,
+    auth: Any = None,
+    follow_redirects: bool = False,
+    timeout: float = 5.0,
+    **kwargs,
+):
+    """Async context manager that yields an ``httpx.AsyncClient`` bound to *app*.
+
+    Canonical helper for Tachyon tests — mirrors the pattern used throughout
+    the test suite.  All httpx options (cookies, auth, headers, timeouts,
+    follow_redirects) are forwarded to the underlying client.
+
+    Example::
+
+        async with create_client(app) as client:
+            r = await client.get("/healthz")
+            assert r.status_code == 200
+    """
+    client_kwargs: Dict[str, Any] = {
+        "transport": ASGITransport(app=app),
+        "base_url": base_url,
+        "follow_redirects": follow_redirects,
+        "timeout": timeout,
+        **kwargs,
+    }
+    if headers:
+        client_kwargs["headers"] = headers
+    if cookies:
+        client_kwargs["cookies"] = cookies
+    if auth is not None:
+        client_kwargs["auth"] = auth
+
+    async with AsyncClient(**client_kwargs) as client:
+        yield client


### PR DESCRIPTION
Moves `create_client` into the framework's own `testing.py` so users can `from tachyon_api.testing import create_client`. Adds explicit httpx kwargs (headers, cookies, auth, follow_redirects, timeout) to both `create_client` and `AsyncTachyonTestClient`.