### PR TITLE
feat(di): singleton/request/transient scopes for @injectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`core/lifecycle.py`** — Startup handlers now raise `RuntimeError` on failure (with the original exception as cause), preventing the app from booting in a broken state. Shutdown handlers log failures at WARNING and continue processing remaining handlers.
 - **`cache.py`** — `RedisCacheBackend.clear()` now calls `flushdb()` (current DB only) instead of silently no-oping. Falls back to `flushall()` if `flushdb()` is unavailable.
 
+### Added
+
+- **`tachyon_api/testing.py`** — `create_client(app, ...)` async context manager promoted from `tests/helpers.py` to the framework's public testing module. Accepts all httpx kwargs (headers, cookies, auth, follow_redirects, timeout). `AsyncTachyonTestClient` gains the same explicit parameters for discoverability.
+- **`di.py`** — `@injectable` now accepts an optional `scope` keyword: `"singleton"` *(default, unchanged)*, `"request"` *(one instance per HTTP request, cached in per-request dependency_cache)*, `"transient"` *(new instance on every injection)*. Backward-compatible: bare `@injectable` still means singleton. Exports `SCOPE_SINGLETON`, `SCOPE_REQUEST`, `SCOPE_TRANSIENT` constants.
+- **`core/websocket.py`** — WebSocket handlers now support typed path params (converted via `TypeConverter` based on annotations; type mismatch closes with code 1008), `@injectable` class deps, and `Depends(callable)` per-connection factories. Param descriptors are pre-computed at route registration (zero `inspect` overhead per connection).
+- **`openapi.py`** — `generate_route` now generates correct OpenAPI for: `response_model=List[Struct]` (array schema with `$ref`), `Body` with `List[Struct]` (JSON requestBody), `Form` and `File` params (`multipart/form-data` requestBody with `required` fields and `format: binary` for files).
+
 ### Fixed (continued)
 
 - **`security.py`** — `_APIKeyBase._get_raw()` is now a proper `@abstractmethod` (via `ABC`); direct instantiation of the base class is caught at class definition time instead of raising `NotImplementedError` at runtime.

--- a/tachyon_api/di.py
+++ b/tachyon_api/di.py
@@ -1,24 +1,57 @@
-"""Dependency injection: Depends marker and @injectable registry."""
+"""Dependency injection: Depends marker, @injectable registry, and scope management."""
 
-from typing import Set, Type, TypeVar, Callable, Optional, Any
+from typing import Dict, Optional, Set, Type, TypeVar, Callable, Any
 
 _registry: Set[Type] = set()
+_scopes: Dict[Type, str] = {}  # class → "singleton" | "request" | "transient"
 
 T = TypeVar("T")
 
+SCOPE_SINGLETON  = "singleton"
+SCOPE_REQUEST    = "request"
+SCOPE_TRANSIENT  = "transient"
+
 
 class Depends:
-    """
-    Marker for explicit dependency injection.
+    """Marker for explicit dependency injection.
 
-    Depends() resolves by type annotation; Depends(callable) calls the factory.
+    ``Depends()`` resolves by type annotation (class-based DI).
+    ``Depends(callable)`` calls the factory and injects the result.
     """
 
     def __init__(self, dependency: Optional[Callable[..., Any]] = None):
         self.dependency = dependency
 
 
-def injectable(cls: Type[T]) -> Type[T]:
-    """Decorator to register a class for automatic dependency resolution."""
-    _registry.add(cls)
-    return cls
+def injectable(_cls: Optional[Type[T]] = None, *, scope: str = SCOPE_SINGLETON) -> Any:
+    """Register a class for automatic dependency resolution.
+
+    Supports three scopes:
+
+    - ``"singleton"`` *(default)* — one instance per application lifetime,
+      cached in ``app._instances_cache``.
+    - ``"request"`` — one instance per HTTP request, cached in the
+      per-request ``dependency_cache`` dict.
+    - ``"transient"`` — a fresh instance on every injection.
+
+    Usage::
+
+        @injectable                        # singleton (default)
+        class DB: ...
+
+        @injectable(scope="request")       # new instance per request
+        class RequestContext: ...
+
+        @injectable(scope="transient")     # new instance every time
+        class UnitOfWork: ...
+    """
+    def decorator(cls: Type[T]) -> Type[T]:
+        _registry.add(cls)
+        _scopes[cls] = scope
+        return cls
+
+    if _cls is not None:
+        # Called as bare @injectable (no parentheses)
+        return decorator(_cls)
+    # Called as @injectable(scope=...) — return the decorator
+    return decorator

--- a/tachyon_api/processing/compiler.py
+++ b/tachyon_api/processing/compiler.py
@@ -94,7 +94,12 @@ class CompiledEndpoint:
         self.params = params
         # Pre-computed flags — zero cost at request time
         self.has_params = bool(params)
-        self.has_callable_deps = any(p.kind == KIND_DEP_CALLABLE for p in params)
+        from ..di import _scopes, SCOPE_SINGLETON
+        self.has_callable_deps = any(
+            p.kind == KIND_DEP_CALLABLE
+            or (p.kind == KIND_DEP_CLASS and _scopes.get(p.annotation, SCOPE_SINGLETON) != SCOPE_SINGLETON)
+            for p in params
+        )
         self.has_path_params = any(p.kind in (KIND_PATH, KIND_PATH_IMPLICIT) for p in params)
         # Pre-computed length — used to pre-allocate the args list in process_parameters
         self.param_count = len(params)

--- a/tachyon_api/processing/dependencies.py
+++ b/tachyon_api/processing/dependencies.py
@@ -10,7 +10,7 @@ _SIG_CACHE: Dict[Callable, inspect.Signature] = {}
 
 from starlette.requests import Request
 
-from ..di import Depends, _registry
+from ..di import Depends, _registry, _scopes, SCOPE_SINGLETON, SCOPE_REQUEST, SCOPE_TRANSIENT
 from .scope import TachyonScope
 
 
@@ -19,7 +19,9 @@ class DependencyResolver:
         self.app = app_instance
         self._resolving: set = set()
 
-    def resolve_dependency(self, cls: Type) -> Any:
+    def resolve_dependency(self, cls: Type, request_cache: "Dict | None" = None) -> Any:
+        scope = _scopes.get(cls, SCOPE_SINGLETON)
+
         if cls in self.app.dependency_overrides:
             override = self.app.dependency_overrides[cls]
             if callable(override) and not isinstance(override, type):
@@ -28,9 +30,15 @@ class DependencyResolver:
                 return override()
             return override
 
-        cached = self.app.get_instance(cls)
-        if cached is not None:
-            return cached
+        # Check scope-appropriate cache
+        if scope == SCOPE_SINGLETON:
+            cached = self.app.get_instance(cls)
+            if cached is not None:
+                return cached
+        elif scope == SCOPE_REQUEST:
+            if request_cache is not None and cls in request_cache:
+                return request_cache[cls]
+        # SCOPE_TRANSIENT: no cache check — always create
 
         if cls not in _registry:
             try:
@@ -46,8 +54,12 @@ class DependencyResolver:
                 f"Circular dependency detected while resolving '{cls.__name__}'"
             )
 
-        sig = inspect.signature(cls)
-        dependencies = {}
+        sig = _SIG_CACHE.get(cls)
+        if sig is None:
+            sig = inspect.signature(cls)
+            _SIG_CACHE[cls] = sig
+
+        nested: Dict[str, Any] = {}
         self._resolving.add(cls)
         try:
             for param in sig.parameters.values():
@@ -57,15 +69,18 @@ class DependencyResolver:
                             f"Parameter '{param.name}' in '{cls.__name__}' has no type annotation; "
                             f"cannot resolve dependency."
                         )
-                    dependencies[param.name] = self.resolve_dependency(param.annotation)
+                    nested[param.name] = self.resolve_dependency(param.annotation, request_cache)
         finally:
             self._resolving.discard(cls)
 
-        instance = cls(**dependencies)
-        # register_instance is the public API; singletons are app-scoped (not request-scoped).
-        # In pure asyncio, resolve_dependency is synchronous so there is no concurrent
-        # mutation risk; multi-threaded servers should use request-scoped Depends() instead.
-        self.app.register_instance(cls, instance)
+        instance = cls(**nested)
+
+        if scope == SCOPE_SINGLETON:
+            self.app.register_instance(cls, instance)
+        elif scope == SCOPE_REQUEST and request_cache is not None:
+            request_cache[cls] = instance
+        # SCOPE_TRANSIENT: no caching
+
         return instance
 
     async def resolve_callable_dependency(

--- a/tachyon_api/processing/parameters.py
+++ b/tachyon_api/processing/parameters.py
@@ -65,7 +65,7 @@ class ParameterProcessor:
                 )
 
             elif kind == KIND_DEP_CLASS:
-                args[i] = self.app._dependency_resolver.resolve_dependency(p.annotation)
+                args[i] = self.app._dependency_resolver.resolve_dependency(p.annotation, dependency_cache)
 
             elif kind == KIND_BODY:
                 val, err = await self._process_body(p, request)


### PR DESCRIPTION
Adds scope support to `@injectable`: singleton (default, unchanged), request (one instance per HTTP request), transient (new on every injection). Fully backward-compatible.