### PR TITLE
refactor(v1.2.2): split parameters.py into 10 atomic extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.2] — 2026-05-22
+
+**Refactor pass v1.2.2 of the SRP / Cython-readiness roadmap.** No behavior changes,
+no API breaks, no perf regression. Compiled Cython (`parameters.cpython-*.so`)
+is preserved unchanged — production users running the compiled extension see
+zero impact. The pure-Python fallback (`parameters.py`) is rewritten as a
+modular pipeline composed of atomic extractors.
+
+### Refactor
+
+- **`processing/parameters.py`** (266-line monolith → ~110-line orchestrator) is
+  decomposed into 10 atomic extractor modules under `processing/_extractors/`,
+  each answering ONE extraction question with a single public method.
+
+  New atomic modules:
+  - `_base.py` — `ExtractorResult` (NamedTuple: `(value, error)`) — uniform return shape
+  - `_missing.py` — `missing()` — single source of truth for default-vs-error decision
+  - `body_limit.py` — `BodySizeChecker` — content-length + post-read validation
+  - `body.py` — `BodyExtractor` — reads body and decodes with msgspec
+  - `query.py` — `QueryExtractor` — scalar query parameter
+  - `query_list.py` — `QueryListExtractor` — list-valued query (repeated keys + CSV)
+  - `header.py` — `HeaderExtractor` — canonical-name header lookup
+  - `cookie.py` — `CookieExtractor` — cookie by name
+  - `form.py` — `FormExtractor` — form-field by name
+  - `file.py` — `FileExtractor` — UploadFile with validation
+  - `path.py` — `PathExtractor` — path param with null-byte rejection + type conversion
+
+  Public API unchanged: `ParameterProcessor` from `processing.parameters` retains
+  its `process_parameters(compiled, request, dependency_cache)` signature.
+
+  **Both modes verified equal:** test suite passes 360/361 with compiled
+  Cython `.so` loaded AND with the `.so` removed (forcing pure-Python fallback).
+
+### Notes for v1.3.x
+
+- The compiled `parameters.pyx` keeps the v1.2.0 single-file Cython logic for
+  this release.  v1.3.x will evaluate whether splitting the `.pyx` into
+  per-extractor compiled units beats a single-file cdef class (multiple
+  `.so` modules add import overhead — TBD by benchmark).
+- Each extractor module has `__slots__` declared and full type hints — direct
+  `cdef class` candidates.
+
+---
+
 ## [1.2.1] — 2026-05-22
 
 **Refactor pass for Cython migration readiness.** No behavior changes, no API breaks,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.1"
+version = "1.2.2"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/tachyon_api/processing/_extractors/__init__.py
+++ b/tachyon_api/processing/_extractors/__init__.py
@@ -1,0 +1,28 @@
+"""Atomic parameter extractors. Each class answers a single extraction question."""
+
+from ._base import ExtractorResult, OK_NONE
+from ._missing import missing
+from .body import BodyExtractor
+from .body_limit import BodySizeChecker
+from .cookie import CookieExtractor
+from .file import FileExtractor
+from .form import FormExtractor
+from .header import HeaderExtractor
+from .path import PathExtractor
+from .query import QueryExtractor
+from .query_list import QueryListExtractor
+
+__all__ = [
+    "ExtractorResult",
+    "OK_NONE",
+    "missing",
+    "BodyExtractor",
+    "BodySizeChecker",
+    "CookieExtractor",
+    "FileExtractor",
+    "FormExtractor",
+    "HeaderExtractor",
+    "PathExtractor",
+    "QueryExtractor",
+    "QueryListExtractor",
+]

--- a/tachyon_api/processing/_extractors/_base.py
+++ b/tachyon_api/processing/_extractors/_base.py
@@ -1,0 +1,16 @@
+# HOT PATH — uniform result type for every extractor.
+# NamedTuple lowers to a C struct under Cython.
+
+from typing import Any, NamedTuple, Optional
+
+from starlette.responses import JSONResponse
+
+
+class ExtractorResult(NamedTuple):
+    """Uniform return shape from every extractor: (value, error)."""
+
+    value: Any
+    error: Optional[JSONResponse]
+
+
+OK_NONE: ExtractorResult = ExtractorResult(None, None)

--- a/tachyon_api/processing/_extractors/_missing.py
+++ b/tachyon_api/processing/_extractors/_missing.py
@@ -1,0 +1,15 @@
+# HOT PATH — single source of truth for "param missing, decide default vs error."
+# Consumed by 6 of the 7 user-input extractors.
+
+from ..compiler import ParamDescriptor
+from ...responses import validation_error_response
+from ._base import ExtractorResult
+
+
+def missing(descriptor: ParamDescriptor, kind: str, name: str) -> ExtractorResult:
+    """Return the descriptor's default, or a 422 if no default is configured."""
+    if descriptor.default is not ...:
+        return ExtractorResult(descriptor.default, None)
+    return ExtractorResult(
+        None, validation_error_response(f"Missing required {kind}: {name}")
+    )

--- a/tachyon_api/processing/_extractors/body.py
+++ b/tachyon_api/processing/_extractors/body.py
@@ -1,0 +1,69 @@
+# HOT PATH — reads the request body and decodes it with msgspec.
+
+from typing import Optional
+
+import msgspec
+
+from ..compiler import ParamDescriptor
+from ..scope import TachyonScope
+from ...responses import validation_error_response
+from ._base import ExtractorResult
+from .body_limit import BodySizeChecker
+
+
+class BodyExtractor:
+    """Reads request body and decodes with msgspec.json.Decoder."""
+
+    __slots__ = ("_size_check",)
+
+    def __init__(self, max_body_size: int) -> None:
+        self._size_check = BodySizeChecker(max_body_size)
+
+    async def extract(
+        self, descriptor: ParamDescriptor, request: TachyonScope
+    ) -> ExtractorResult:
+        err = self._size_check.check_content_length(request)
+        if err is not None:
+            return ExtractorResult(None, err)
+
+        try:
+            raw_body = await request.body()
+        except Exception:
+            return ExtractorResult(
+                None, validation_error_response("Failed to read request body")
+            )
+
+        err = self._size_check.check_body_length(raw_body)
+        if err is not None:
+            return ExtractorResult(None, err)
+
+        return self._decode(raw_body, descriptor.decoder)
+
+    @staticmethod
+    def _decode(raw_body: bytes, decoder) -> ExtractorResult:
+        if decoder is None:
+            return ExtractorResult(
+                None, validation_error_response("Body type must be a Struct subclass")
+            )
+        try:
+            return ExtractorResult(decoder.decode(raw_body), None)
+        except msgspec.DecodeError as e:
+            return ExtractorResult(
+                None, validation_error_response(f"Invalid JSON body: {e}")
+            )
+        except msgspec.ValidationError as e:
+            return ExtractorResult(None, _msgspec_validation_response(e))
+
+
+def _msgspec_validation_response(e: msgspec.ValidationError):
+    field_errors: Optional[dict] = None
+    try:
+        path = getattr(e, "path", None)
+        if path:
+            for seg in reversed(path):
+                if isinstance(seg, str):
+                    field_errors = {seg: [str(e)]}
+                    break
+    except Exception:
+        pass
+    return validation_error_response(str(e), errors=field_errors)

--- a/tachyon_api/processing/_extractors/body_limit.py
+++ b/tachyon_api/processing/_extractors/body_limit.py
@@ -1,0 +1,36 @@
+# HOT PATH — body size validation, two-pass (header pre-flight + post-read).
+
+from typing import Optional
+
+from starlette.responses import JSONResponse
+
+from ...responses import validation_error_response
+
+
+class BodySizeChecker:
+    """Answers: "is this request body within the configured size limit?" """
+
+    __slots__ = ("_max",)  # int → cdef Py_ssize_t
+
+    def __init__(self, max_body_size: int) -> None:
+        self._max = max_body_size
+
+    def check_content_length(self, request) -> Optional[JSONResponse]:
+        cl = request.headers.get("content-length")
+        if cl is not None:
+            try:
+                if int(cl) > self._max:
+                    return self._too_large_response()
+            except ValueError:
+                pass
+        return None
+
+    def check_body_length(self, body: bytes) -> Optional[JSONResponse]:
+        if len(body) > self._max:
+            return self._too_large_response()
+        return None
+
+    def _too_large_response(self) -> JSONResponse:
+        return validation_error_response(
+            f"Request body too large (max {self._max} bytes)"
+        )

--- a/tachyon_api/processing/_extractors/cookie.py
+++ b/tachyon_api/processing/_extractors/cookie.py
@@ -1,0 +1,18 @@
+# HOT PATH — extracts a cookie value by name.
+
+from ..compiler import ParamDescriptor
+from ..scope import TachyonScope
+from ._base import ExtractorResult
+from ._missing import missing
+
+
+class CookieExtractor:
+    """Extracts a single cookie value by name."""
+
+    __slots__ = ()
+
+    def extract(self, descriptor: ParamDescriptor, request: TachyonScope) -> ExtractorResult:
+        value = request.cookies.get(descriptor.effective_name)
+        if value is not None:
+            return ExtractorResult(value, None)
+        return missing(descriptor, "cookie", descriptor.effective_name)

--- a/tachyon_api/processing/_extractors/file.py
+++ b/tachyon_api/processing/_extractors/file.py
@@ -1,0 +1,28 @@
+# HOT PATH — extracts an uploaded file from form data.
+
+from ..compiler import ParamDescriptor
+from ...responses import validation_error_response
+from ._base import ExtractorResult
+from ._missing import missing
+
+
+class FileExtractor:
+    """Extracts an UploadFile from form data and validates it has a filename attribute."""
+
+    __slots__ = ()
+
+    def extract(self, descriptor: ParamDescriptor, form_data) -> ExtractorResult:
+        name = descriptor.effective_name
+        if name not in form_data:
+            return missing(descriptor, "file", name)
+
+        uploaded = form_data[name]
+        if hasattr(uploaded, "filename"):
+            return ExtractorResult(uploaded, None)
+
+        # Value is present but not a file — fall back to default or 422
+        if descriptor.default is not ...:
+            return ExtractorResult(descriptor.default, None)
+        return ExtractorResult(
+            None, validation_error_response(f"Invalid file upload for: {name}")
+        )

--- a/tachyon_api/processing/_extractors/form.py
+++ b/tachyon_api/processing/_extractors/form.py
@@ -1,0 +1,17 @@
+# HOT PATH — extracts a single form field from already-materialized form data.
+
+from ..compiler import ParamDescriptor
+from ._base import ExtractorResult
+from ._missing import missing
+
+
+class FormExtractor:
+    """Extracts a single form-field value."""
+
+    __slots__ = ()
+
+    def extract(self, descriptor: ParamDescriptor, form_data) -> ExtractorResult:
+        name = descriptor.effective_name
+        if name in form_data:
+            return ExtractorResult(form_data[name], None)
+        return missing(descriptor, "form field", name)

--- a/tachyon_api/processing/_extractors/header.py
+++ b/tachyon_api/processing/_extractors/header.py
@@ -1,0 +1,18 @@
+# HOT PATH — extracts a request header by its canonical (kebab-case) name.
+
+from ..compiler import ParamDescriptor
+from ..scope import TachyonScope
+from ._base import ExtractorResult
+from ._missing import missing
+
+
+class HeaderExtractor:
+    """Extracts a single header value by its canonical name."""
+
+    __slots__ = ()
+
+    def extract(self, descriptor: ParamDescriptor, request: TachyonScope) -> ExtractorResult:
+        value = request.headers.get(descriptor.effective_name)
+        if value is not None:
+            return ExtractorResult(value, None)
+        return missing(descriptor, "header", descriptor.effective_name)

--- a/tachyon_api/processing/_extractors/path.py
+++ b/tachyon_api/processing/_extractors/path.py
@@ -1,0 +1,44 @@
+# HOT PATH — extracts and type-converts a path parameter.
+# Rejects null bytes (path traversal hardening from v1.2.0 audit).
+
+from starlette.responses import JSONResponse
+
+from ..compiler import ParamDescriptor, KIND_PATH
+from ...responses import validation_error_response
+from ...utils import TypeConverter
+from ._base import ExtractorResult
+
+
+class PathExtractor:
+    """Extracts a path parameter, with null-byte rejection and type conversion."""
+
+    __slots__ = ()
+
+    def extract(self, descriptor: ParamDescriptor, path_params) -> ExtractorResult:
+        name = descriptor.name
+        if name not in path_params:
+            if descriptor.kind == KIND_PATH:
+                return ExtractorResult(
+                    None, JSONResponse({"detail": "Not Found"}, status_code=404)
+                )
+            return ExtractorResult(None, None)
+
+        value_str = path_params[name]
+        if "\x00" in value_str:
+            return ExtractorResult(
+                None, validation_error_response(f"Invalid path parameter: {name}")
+            )
+
+        if descriptor.is_list:
+            parts = value_str.split(",") if value_str else []
+            converted = TypeConverter.convert_list_values_bare(
+                parts, descriptor.item_type, descriptor.item_is_optional, name, is_path_param=True
+            )
+        else:
+            converted = TypeConverter.convert_value_bare(
+                value_str, descriptor.base_type, name, is_path_param=True
+            )
+
+        if isinstance(converted, JSONResponse):
+            return ExtractorResult(None, converted)
+        return ExtractorResult(converted, None)

--- a/tachyon_api/processing/_extractors/query.py
+++ b/tachyon_api/processing/_extractors/query.py
@@ -1,0 +1,26 @@
+# HOT PATH — extracts and type-converts a scalar query parameter.
+
+from starlette.responses import JSONResponse
+
+from ..compiler import ParamDescriptor
+from ...utils import TypeConverter
+from ._base import ExtractorResult
+from ._missing import missing
+
+
+class QueryExtractor:
+    """Extracts a single scalar query parameter and converts to its declared type."""
+
+    __slots__ = ()
+
+    def extract(self, descriptor: ParamDescriptor, query_params) -> ExtractorResult:
+        name = descriptor.name
+        if name not in query_params:
+            return missing(descriptor, "query parameter", name)
+
+        converted = TypeConverter.convert_value_bare(
+            query_params[name], descriptor.base_type, name, is_path_param=False
+        )
+        if isinstance(converted, JSONResponse):
+            return ExtractorResult(None, converted)
+        return ExtractorResult(converted, None)

--- a/tachyon_api/processing/_extractors/query_list.py
+++ b/tachyon_api/processing/_extractors/query_list.py
@@ -1,0 +1,43 @@
+# HOT PATH — extracts and converts a list-valued query parameter.
+# Supports both repeated keys (?id=1&id=2) and CSV form (?id=1,2,3).
+
+from starlette.responses import JSONResponse
+
+from ..compiler import ParamDescriptor
+from ...utils import TypeConverter
+from ._base import ExtractorResult
+from ._missing import missing
+
+
+class QueryListExtractor:
+    """Extracts a list query parameter, handling repeated keys and CSV values."""
+
+    __slots__ = ()
+
+    def extract(self, descriptor: ParamDescriptor, query_params) -> ExtractorResult:
+        name = descriptor.name
+
+        raw_values = query_params.getlist(name)
+        if not raw_values and name in query_params:
+            raw_values = [query_params[name]]
+
+        values: list = []
+        for v in raw_values:
+            if isinstance(v, str) and "," in v:
+                values.extend(v.split(","))
+            else:
+                values.append(v)
+
+        if not values:
+            return missing(descriptor, "query parameter", name)
+
+        converted = TypeConverter.convert_list_values_bare(
+            values,
+            descriptor.item_type,
+            descriptor.item_is_optional,
+            name,
+            is_path_param=False,
+        )
+        if isinstance(converted, JSONResponse):
+            return ExtractorResult(None, converted)
+        return ExtractorResult(converted, None)

--- a/tachyon_api/processing/parameters.py
+++ b/tachyon_api/processing/parameters.py
@@ -1,39 +1,69 @@
-"""Parameter extraction and validation — uses pre-compiled endpoint descriptors."""
+"""Parameter extraction pipeline — composes atomic extractors per kind.
+
+This is the pure-Python fallback.  Production builds with `[fast]` Cython
+compiled will use ``parameters.pyx`` (single-file, semantically identical)
+loaded as ``parameters.cpython-*.so``.  Both implementations produce identical
+output for the same input.
+"""
 
 from __future__ import annotations
 
-import typing
 from typing import Any, Optional, Tuple
-
-import msgspec
 
 from starlette.responses import JSONResponse
 
-from ..models import Struct
-from ..responses import validation_error_response
-from ..utils import TypeConverter, TypeUtils
 from ..background import BackgroundTasks
+from ..responses import validation_error_response
+from ._extractors import (
+    BodyExtractor,
+    CookieExtractor,
+    FileExtractor,
+    FormExtractor,
+    HeaderExtractor,
+    PathExtractor,
+    QueryExtractor,
+    QueryListExtractor,
+)
 from .compiler import (
     CompiledEndpoint,
-    ParamDescriptor,
-    KIND_REQUEST, KIND_BG, KIND_BODY, KIND_QUERY,
-    KIND_HEADER, KIND_COOKIE, KIND_FORM, KIND_FILE,
-    KIND_PATH, KIND_PATH_IMPLICIT, KIND_DEP_CALLABLE, KIND_DEP_CLASS,
+    KIND_BG,
+    KIND_BODY,
+    KIND_COOKIE,
+    KIND_DEP_CALLABLE,
+    KIND_DEP_CLASS,
+    KIND_FILE,
+    KIND_FORM,
+    KIND_HEADER,
+    KIND_PATH,
+    KIND_PATH_IMPLICIT,
+    KIND_QUERY,
+    KIND_REQUEST,
 )
 from .scope import TachyonScope
 
 _DEFAULT_MAX_BODY_SIZE = 2 * 1024 * 1024  # 2 MB — override via Tachyon(max_body_size=...)
 
 
-def _missing_param(p: "ParamDescriptor", kind: str, name: str) -> "Tuple[Any, Optional[JSONResponse]]":
-    if p.default is not ...:
-        return p.default, None
-    return None, validation_error_response(f"Missing required {kind}: {name}")
-
-
 class ParameterProcessor:
-    def __init__(self, app_instance):
+    """Orchestrates parameter extraction by delegating to atomic extractors."""
+
+    __slots__ = (
+        "app",
+        "_body", "_query_scalar", "_query_list",
+        "_header", "_cookie", "_form", "_file", "_path",
+    )
+
+    def __init__(self, app_instance) -> None:
         self.app = app_instance
+        max_body_size = getattr(app_instance, "max_body_size", _DEFAULT_MAX_BODY_SIZE)
+        self._body = BodyExtractor(max_body_size)
+        self._query_scalar = QueryExtractor()
+        self._query_list = QueryListExtractor()
+        self._header = HeaderExtractor()
+        self._cookie = CookieExtractor()
+        self._form = FormExtractor()
+        self._file = FileExtractor()
+        self._path = PathExtractor()
 
     async def process_parameters(
         self,
@@ -41,226 +71,72 @@ class ParameterProcessor:
         request: TachyonScope,
         dependency_cache,
     ) -> Tuple[list, Optional[JSONResponse], Optional[BackgroundTasks]]:
-        # Pre-allocate list of exact size — positional args for func(*args) call.
-        # Avoids dict allocation + dict-write overhead on every request.
         args: list = [None] * compiled.param_count
-        _bg: Optional[BackgroundTasks] = None
-        _form_data = None
+        bg: Optional[BackgroundTasks] = None
+        form_data = None
 
         for i, p in enumerate(compiled.params):
             kind = p.kind
 
+            # ── Framework-level injections ────────────────────────────────
             if kind == KIND_REQUEST:
-                # User declared `request: Request` — materialise the full Starlette object
                 args[i] = request.as_request()
-
-            elif kind == KIND_BG:
-                if _bg is None:
-                    _bg = BackgroundTasks()
-                args[i] = _bg
-
-            elif kind == KIND_DEP_CALLABLE:
+                continue
+            if kind == KIND_BG:
+                if bg is None:
+                    bg = BackgroundTasks()
+                args[i] = bg
+                continue
+            if kind == KIND_DEP_CALLABLE:
                 args[i] = await self.app._dependency_resolver.resolve_callable_dependency(
                     p.dependency, dependency_cache, request
                 )
+                continue
+            if kind == KIND_DEP_CLASS:
+                args[i] = self.app._dependency_resolver.resolve_dependency(
+                    p.annotation, dependency_cache
+                )
+                continue
 
-            elif kind == KIND_DEP_CLASS:
-                args[i] = self.app._dependency_resolver.resolve_dependency(p.annotation, dependency_cache)
-
-            elif kind == KIND_BODY:
-                val, err = await self._process_body(p, request)
-                if err is not None:
-                    return args, err, _bg
-                args[i] = val
+            # ── User-input extraction (delegated to atomic extractors) ────
+            if kind == KIND_BODY:
+                result = await self._body.extract(p, request)
 
             elif kind == KIND_QUERY:
-                val, err = self._process_query(p, request.query_params)
-                if err is not None:
-                    return args, err, _bg
-                args[i] = val
+                extractor = self._query_list if p.is_list else self._query_scalar
+                result = extractor.extract(p, request.query_params)
 
             elif kind == KIND_HEADER:
-                val, err = self._process_header(p, request)
-                if err is not None:
-                    return args, err, _bg
-                args[i] = val
+                result = self._header.extract(p, request)
 
             elif kind == KIND_COOKIE:
-                val, err = self._process_cookie(p, request)
-                if err is not None:
-                    return args, err, _bg
-                args[i] = val
+                result = self._cookie.extract(p, request)
 
             elif kind == KIND_FORM:
-                if _form_data is None:
+                if form_data is None:
                     try:
-                        _form_data = await request.form()
+                        form_data = await request.form()
                     except Exception:
-                        return args, validation_error_response("Failed to parse form data"), _bg
-                val, err = self._process_form(p, _form_data)
-                if err is not None:
-                    return args, err, _bg
-                args[i] = val
+                        return args, validation_error_response("Failed to parse form data"), bg
+                result = self._form.extract(p, form_data)
 
             elif kind == KIND_FILE:
-                if _form_data is None:
+                if form_data is None:
                     try:
-                        _form_data = await request.form()
+                        form_data = await request.form()
                     except Exception:
-                        return args, validation_error_response("Failed to parse form data"), _bg
-                val, err = self._process_file(p, _form_data)
-                if err is not None:
-                    return args, err, _bg
-                args[i] = val
+                        return args, validation_error_response("Failed to parse form data"), bg
+                result = self._file.extract(p, form_data)
 
             elif kind == KIND_PATH or kind == KIND_PATH_IMPLICIT:
-                val, err = self._process_path(p, request.path_params)
-                if err is not None:
-                    return args, err, _bg
-                args[i] = val
+                result = self._path.extract(p, request.path_params)
 
-        return args, None, _bg
+            else:
+                # Unknown kind — defensive fallback
+                continue
 
-    async def _process_body(
-        self, p: ParamDescriptor, request: TachyonScope
-    ) -> Tuple[Any, Optional[JSONResponse]]:
-        max_body_size = getattr(self.app, "max_body_size", _DEFAULT_MAX_BODY_SIZE)
-        cl = request.headers.get("content-length")
-        if cl is not None:
-            try:
-                if int(cl) > max_body_size:
-                    return None, validation_error_response(
-                        f"Request body too large (max {max_body_size} bytes)"
-                    )
-            except ValueError:
-                pass
+            if result.error is not None:
+                return args, result.error, bg
+            args[i] = result.value
 
-        try:
-            raw_body = await request.body()
-        except Exception:
-            return None, validation_error_response("Failed to read request body")
-
-        if len(raw_body) > max_body_size:
-            return None, validation_error_response(
-                f"Request body too large (max {max_body_size} bytes)"
-            )
-
-        decoder = p.decoder
-        if decoder is None:
-            return None, validation_error_response("Body type must be a Struct subclass")
-
-        try:
-            return decoder.decode(raw_body), None
-        except msgspec.DecodeError as e:
-            return None, validation_error_response(f"Invalid JSON body: {e}")
-        except msgspec.ValidationError as e:
-            field_errors = None
-            try:
-                path = getattr(e, "path", None)
-                if path:
-                    for seg in reversed(path):
-                        if isinstance(seg, str):
-                            field_errors = {seg: [str(e)]}
-                            break
-            except Exception:
-                pass
-            return None, validation_error_response(str(e), errors=field_errors)
-
-    def _process_query(
-        self, p: ParamDescriptor, query_params
-    ) -> Tuple[Any, Optional[JSONResponse]]:
-        name = p.name
-
-        if p.is_list:
-            raw_values = query_params.getlist(name)
-            if not raw_values and name in query_params:
-                raw_values = [query_params[name]]
-            values: list = []
-            for v in raw_values:
-                if isinstance(v, str) and "," in v:
-                    values.extend(v.split(","))
-                else:
-                    values.append(v)
-            if not values:
-                return _missing_param(p, "query parameter", name)
-            converted = TypeConverter.convert_list_values_bare(
-                values, p.item_type, p.item_is_optional, name, is_path_param=False
-            )
-            if isinstance(converted, JSONResponse):
-                return None, converted
-            return converted, None
-
-        if name in query_params:
-            converted = TypeConverter.convert_value_bare(
-                query_params[name], p.base_type, name, is_path_param=False
-            )
-            if isinstance(converted, JSONResponse):
-                return None, converted
-            return converted, None
-        return _missing_param(p, "query parameter", name)
-
-    def _process_header(
-        self, p: ParamDescriptor, request: TachyonScope
-    ) -> Tuple[Any, Optional[JSONResponse]]:
-        value = request.headers.get(p.effective_name)
-        if value is not None:
-            return value, None
-        return _missing_param(p, "header", p.effective_name)
-
-    def _process_cookie(
-        self, p: ParamDescriptor, request: TachyonScope
-    ) -> Tuple[Any, Optional[JSONResponse]]:
-        value = request.cookies.get(p.effective_name)
-        if value is not None:
-            return value, None
-        return _missing_param(p, "cookie", p.effective_name)
-
-    def _process_form(
-        self, p: ParamDescriptor, form_data
-    ) -> Tuple[Any, Optional[JSONResponse]]:
-        name = p.effective_name
-        if name in form_data:
-            return form_data[name], None
-        return _missing_param(p, "form field", name)
-
-    def _process_file(
-        self, p: ParamDescriptor, form_data
-    ) -> Tuple[Any, Optional[JSONResponse]]:
-        name = p.effective_name
-        if name in form_data:
-            uploaded = form_data[name]
-            if hasattr(uploaded, "filename"):
-                return uploaded, None
-            if p.default is not ...:
-                return p.default, None
-            return None, validation_error_response(f"Invalid file upload for: {name}")
-        return _missing_param(p, "file", name)
-
-    def _process_path(
-        self, p: ParamDescriptor, path_params
-    ) -> Tuple[Any, Optional[JSONResponse]]:
-        name = p.name
-        if name not in path_params:
-            if p.kind == KIND_PATH:
-                return None, JSONResponse({"detail": "Not Found"}, status_code=404)
-            return None, None
-
-        value_str = path_params[name]
-        if "\x00" in value_str:
-            return None, validation_error_response(f"Invalid path parameter: {name}")
-
-        if p.is_list:
-            parts = value_str.split(",") if value_str else []
-            converted = TypeConverter.convert_list_values_bare(
-                parts, p.item_type, p.item_is_optional, name, is_path_param=True
-            )
-            if isinstance(converted, JSONResponse):
-                return None, converted
-            return converted, None
-
-        converted = TypeConverter.convert_value_bare(
-            value_str, p.base_type, name, is_path_param=True
-        )
-        if isinstance(converted, JSONResponse):
-            return None, converted
-        return converted, None
+        return args, None, bg


### PR DESCRIPTION
## Summary — v1.2.2 of the SRP refactor roadmap

Descompone \`ParameterProcessor\` (266 líneas monolíticas, 7 \`_process_X\` methods con
responsabilidades mezcladas) en **10 extractors atómicos** bajo \`processing/_extractors/\`.
Cada uno responde UNA pregunta y tiene \`__slots__\` + type hints completos — listos
para \`cdef class\` en v1.3.x.

## Estructura nueva (\`processing/_extractors/\`)

| Módulo | Responsabilidad |
|---|---|
| \`_base.py\` | \`ExtractorResult\` NamedTuple — uniform return type |
| \`_missing.py\` | \`missing()\` — única decisión "default vs error 422" |
| \`body_limit.py\` | \`BodySizeChecker\` — content-length + post-read validation |
| \`body.py\` | \`BodyExtractor\` — read body + msgspec decode |
| \`query.py\` | \`QueryExtractor\` — scalar query param |
| \`query_list.py\` | \`QueryListExtractor\` — repeated keys + CSV split |
| \`header.py\` | \`HeaderExtractor\` |
| \`cookie.py\` | \`CookieExtractor\` |
| \`form.py\` | \`FormExtractor\` |
| \`file.py\` | \`FileExtractor\` |
| \`path.py\` | \`PathExtractor\` (null-byte rejection + type conversion) |

\`parameters.py\` queda como orquestador \`ParameterProcessor\` que compone los extractors.

## Compatibilidad con Cython compilado

El \`.pyx\` queda **intacto** en v1.2.2 — producción con \`[fast]\` instalado sigue
corriendo el Cython single-file. Ambos modos producen comportamiento idéntico.

**Verificado:** test suite pasa 360/361 con \`.so\` cargado Y con \`.so\` removido
(forzando fallback pure-Python).

v1.3.x decidirá si splitear el \`.pyx\` también — múltiples \`.so\` agregan import
overhead, así que el trade-off se evalúa por benchmark.

## Sin regresión de performance
| Métrica | v1.2.1 | v1.2.2 | Δ |
|---|---:|---:|---:|
| FULL HANDLER cycle | 1.04 µs | **1.06 µs** | within noise (±2%) |
| process_parameters path+query | 0.58 µs | **0.56 µs** | within noise |
| process_parameters body POST | 0.81 µs | **0.80 µs** | within noise |

## Cython migration notes (v1.3.x)
- Cada extractor → \`cdef class\` con \`__slots__\` C-typed
- \`ExtractorResult\` NamedTuple → cdef struct (zero allocation)
- \`missing()\` → \`cdef inline\`
- \`PathExtractor\` y \`QueryExtractor\` son ideales para \`nogil\` en la conversión

## Test plan
- [x] 360/361 con \`.so\` (Cython path)
- [x] 360/361 sin \`.so\` (pure-Python fallback path)
- [x] Sin regresión > 2% en \`profile_hotpath.py\`