### PR TITLE
fix(v1.2.811): Body(List[Struct]) decoder + ExceptionTable subclass dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.811] — 2026-05-22
+
+**Framework bug fixes discovered during v1.2.81 example modernization.**
+Two v1.2.0 features were documented as working but only half-implemented at
+the runtime layer — surfaced when porting the example to use them directly.
+
+### Fixed
+
+- **`Body(List[Struct])` decoding** — `processing/compiler.py` and
+  `processing/compiler.pyx` (`_build_typed_descriptor`) now attempt to build
+  a `msgspec.json.Decoder` for any `KIND_BODY` annotation, not just direct
+  Struct subclasses.  Previously, `List[Struct]`, `Optional[Struct]`,
+  `Tuple[...]`, and other msgspec-supported generics produced `decoder=None`,
+  causing the body extractor to return `"Body type must be a Struct subclass"`
+  at request time — even though the OpenAPI spec generated correctly.
+
+  Implementation: wrap the decoder construction in `try/except Exception` so
+  msgspec itself decides which types are decodable; unsupported types still
+  leave `decoder=None` and surface the same 422 at request time.
+
+  Cython recompiled (`python setup.py build_ext --inplace`).
+
+- **`@app.exception_handler` for HTTPException subclasses** —
+  `app/_exception_table.py::dispatch` now walks every registered handler in
+  registration order and returns the first `isinstance` match, falling back
+  to the default `{"detail": ...}` body only when no handler matched **and**
+  the exception is an `HTTPException`.
+
+  Previously, the dispatch short-circuited to the default response for any
+  `HTTPException` whenever no handler was registered for `HTTPException`
+  itself — so a handler registered for a subclass like
+  `MyDomainError(HTTPException)` was never invoked.  The example's
+  `@app.exception_handler(KYCException)` was a no-op for this reason.
+
+  Backward-compatible: a handler explicitly registered for `HTTPException`
+  still wins because it appears in the registration-order walk; plain
+  `HTTPException` instances with no subclass handler still get the default
+  body.
+
+### Added
+
+- **`tests/test_v1_2_811_fixes.py`** — 6 regression tests covering:
+  - `Body(List[Struct])` happy-path decoding
+  - `Body(List[Struct])` validation-error path (422)
+  - `Body(Optional[Struct])` decoding
+  - `@app.exception_handler(HTTPException-subclass)` invocation
+  - Plain `HTTPException` still uses the default body when no handler is registered
+  - Explicit `@app.exception_handler(HTTPException)` still wins over the default
+
+### Verified
+
+- 366/367 tests pass (the +6 new tests; pre-existing CLI failure unchanged).
+- Test suite passes in **both** modes: with compiled Cython `.so` loaded
+  (production) and with the `.so` files moved aside (pure-Python fallback).
+- `FULL HANDLER` cycle 1.03–1.11 µs across 3 runs, `process_parameters body POST`
+  0.79–0.82 µs — within noise of v1.2.81 baseline.
+
+### Compiled artifacts updated
+
+- `tachyon_api/processing/compiler.cpython-310-darwin.so`
+- `tachyon_api/processing/compiler.c`
+
+---
+
 ## [1.2.81] — 2026-05-22
 
 **v1.2.8x project audit / Cython prep — sub-version 1/4: modernize `example/`.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.81"
+version = "1.2.811"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/tachyon_api/app/_exception_table.py
+++ b/tachyon_api/app/_exception_table.py
@@ -31,16 +31,24 @@ class ExceptionTable:
         self._handlers[exc_class] = func
 
     async def dispatch(self, exc: Exception, request) -> Optional[Response]:
-        """Find a handler for exc and invoke it. Returns None if no handler matched."""
-        if isinstance(exc, HTTPException):
-            http_handler = self._handlers.get(HTTPException)
-            if http_handler is not None:
-                return await self._invoke(http_handler, request, exc)
-            return self._http_exception_response(exc)
+        """Find a handler for exc and invoke it. Returns None if no handler matched.
 
+        Walks registered handlers in registration order — first `isinstance`
+        match wins.  This is what lets users register a handler for a
+        `HTTPException` *subclass* (e.g., `MyDomainError(HTTPException)`) and
+        have it invoked instead of falling through to the default
+        `{"detail": ...}` response.
+
+        If nothing matched and `exc` is an `HTTPException`, returns the
+        default body.  Other unhandled exceptions return `None` and the
+        caller emits a 500.
+        """
         for exc_class, handler in self._handlers.items():
             if isinstance(exc, exc_class):
                 return await self._invoke(handler, request, exc)
+
+        if isinstance(exc, HTTPException):
+            return self._http_exception_response(exc)
         return None
 
     @staticmethod

--- a/tachyon_api/processing/compiler.py
+++ b/tachyon_api/processing/compiler.py
@@ -200,8 +200,16 @@ def _build_typed_descriptor(name: str, kind: str, ann: Any, marker: Any) -> Para
         effective_name = getattr(marker, "alias", None) or name
 
     decoder = None
-    if kind == KIND_BODY and isinstance(ann, type) and issubclass(ann, Struct):
-        decoder = msgspec.json.Decoder(ann)
+    if kind == KIND_BODY:
+        # msgspec supports Struct, List[Struct], Tuple[...], Optional[Struct],
+        # dict, primitives, etc.  We delegate the "is this decodable" decision
+        # to msgspec by trying to build a decoder — if the type is genuinely
+        # unsupported, msgspec raises and we leave decoder=None so the body
+        # extractor returns a 422 at request time.
+        try:
+            decoder = msgspec.json.Decoder(ann)
+        except Exception:
+            decoder = None
 
     return ParamDescriptor(
         name=name,

--- a/tachyon_api/processing/compiler.pyx
+++ b/tachyon_api/processing/compiler.pyx
@@ -190,8 +190,12 @@ cdef _build_typed_descriptor(str name, int kind, object ann, object marker):
         effective_name = getattr(marker, "alias", None) or name
 
     decoder = None
-    if kind == KIND_BODY and isinstance(ann, type) and issubclass(ann, Struct):
-        decoder = msgspec.json.Decoder(ann)
+    if kind == KIND_BODY:
+        # See compiler.py for rationale — try msgspec, accept any decodable type.
+        try:
+            decoder = msgspec.json.Decoder(ann)
+        except Exception:
+            decoder = None
 
     return ParamDescriptor(
         name=name, kind=kind, annotation=ann, marker=marker,

--- a/tests/test_v1_2_811_fixes.py
+++ b/tests/test_v1_2_811_fixes.py
@@ -1,0 +1,153 @@
+"""Regression tests for the v1.2.811 framework fixes.
+
+Two bugs surfaced while modernizing the example in v1.2.81:
+  1. `Body(List[Struct])` failed at runtime because `compile_endpoint` only
+     built a msgspec decoder for direct Struct subclasses.
+  2. `@app.exception_handler(HTTPException-subclass)` was never invoked because
+     `ExceptionTable.dispatch` short-circuited to the default response.
+"""
+
+from typing import List, Optional
+
+import pytest
+from starlette.responses import JSONResponse
+
+from tachyon_api import Body, HTTPException, Struct, Tachyon
+from tests.helpers import create_client
+
+
+# ── Fix #1: Body(List[Struct]) decodes at runtime ─────────────────────────────
+
+
+class Item(Struct):
+    name: str
+    qty: int
+
+
+@pytest.mark.asyncio
+async def test_body_list_of_structs_decodes():
+    """`Body(List[ItemStruct])` should accept a JSON array and decode it."""
+    app = Tachyon()
+
+    @app.post("/items")
+    def create_items(items: List[Item] = Body(...)):
+        return {"count": len(items), "names": [it.name for it in items]}
+
+    async with create_client(app) as client:
+        response = await client.post(
+            "/items",
+            json=[{"name": "a", "qty": 1}, {"name": "b", "qty": 2}],
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"count": 2, "names": ["a", "b"]}
+
+
+@pytest.mark.asyncio
+async def test_body_list_of_structs_validation_error():
+    """Invalid array item should still produce a 422 via msgspec validation."""
+    app = Tachyon()
+
+    @app.post("/items")
+    def create_items(items: List[Item] = Body(...)):
+        return {"ok": True}
+
+    async with create_client(app) as client:
+        # `qty` is missing on the second item
+        response = await client.post(
+            "/items",
+            json=[{"name": "a", "qty": 1}, {"name": "b"}],
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_body_optional_struct_decodes():
+    """`Body(Optional[Struct])` is also supported by msgspec."""
+    app = Tachyon()
+
+    @app.post("/maybe")
+    def maybe(item: Optional[Item] = Body(...)):
+        return {"received_null": item is None, "name": item.name if item else None}
+
+    async with create_client(app) as client:
+        response = await client.post("/maybe", json={"name": "a", "qty": 1})
+        assert response.status_code == 200
+        assert response.json() == {"received_null": False, "name": "a"}
+
+
+# ── Fix #2: @app.exception_handler(HTTPException subclass) fires ──────────────
+
+
+class _DomainError(HTTPException):
+    """Domain-specific subclass of HTTPException."""
+
+    def __init__(self, detail: str):
+        super().__init__(status_code=418, detail=detail)
+        self.error_code = "TEAPOT"
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_subclass_of_http_exception():
+    """A handler registered for an HTTPException subclass must be invoked."""
+    app = Tachyon()
+
+    @app.exception_handler(_DomainError)
+    async def handle_domain_error(request, exc):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"success": False, "code": exc.error_code, "msg": exc.detail},
+        )
+
+    @app.get("/teapot")
+    def raise_teapot():
+        raise _DomainError("Short and stout")
+
+    async with create_client(app) as client:
+        response = await client.get("/teapot")
+
+    assert response.status_code == 418
+    assert response.json() == {
+        "success": False,
+        "code": "TEAPOT",
+        "msg": "Short and stout",
+    }
+
+
+@pytest.mark.asyncio
+async def test_plain_http_exception_still_returns_default_body():
+    """When no subclass handler matches, plain HTTPException keeps its default body."""
+    app = Tachyon()
+
+    @app.get("/notfound")
+    def raise_404():
+        raise HTTPException(status_code=404, detail="missing")
+
+    async with create_client(app) as client:
+        response = await client.get("/notfound")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "missing"}
+
+
+@pytest.mark.asyncio
+async def test_http_exception_explicit_handler_still_wins_over_default():
+    """A handler explicitly registered for HTTPException itself runs first."""
+    app = Tachyon()
+
+    @app.exception_handler(HTTPException)
+    async def http_handler(request, exc):
+        return JSONResponse(
+            status_code=exc.status_code, content={"caught": exc.detail}
+        )
+
+    @app.get("/explicit")
+    def raise_400():
+        raise HTTPException(status_code=400, detail="bad")
+
+    async with create_client(app) as client:
+        response = await client.get("/explicit")
+
+    assert response.status_code == 400
+    assert response.json() == {"caught": "bad"}


### PR DESCRIPTION
## Summary — v1.2.811 framework hotfixes

Two v1.2.0 features were documented in the CHANGELOG as working but only half-implemented at the runtime layer.  Surfaced while modernizing \`example/\` in v1.2.81 (PR #42).  Fixed here so v1.2.813 can revert the example workarounds.

## Fix #1 — \`Body(List[Struct])\` runtime decoding

\`processing/compiler.py\` + \`processing/compiler.pyx\` now build a \`msgspec.json.Decoder\` for **any** \`KIND_BODY\` annotation, not just direct \`Struct\` subclasses.

Before: \`List[Struct]\`, \`Optional[Struct]\`, \`Tuple[...]\` etc. got \`decoder=None\`, and the body extractor returned a 422 \`"Body type must be a Struct subclass"\` — even though the OpenAPI spec generated correctly (PR #30 v1.2.0).

After: wrap in \`try/except\` so msgspec decides what's decodable.  Unsupported types still leave \`decoder=None\` and surface the same 422.

Cython rebuilt (\`python setup.py build_ext --inplace\`).

## Fix #2 — \`@app.exception_handler\` for HTTPException subclasses

\`app/_exception_table.py::dispatch\` now walks **every** registered handler in registration order, returning the first \`isinstance\` match.  Falls back to the default \`{\"detail\": ...}\` body only when no handler matched AND the exception is an \`HTTPException\`.

Before: any HTTPException short-circuited to the default response unless a handler was registered for \`HTTPException\` exactly.  Handlers registered for a subclass like \`MyDomainError(HTTPException)\` were never invoked.

After: a handler registered for any HTTPException subclass is matched correctly; backward-compatible for the no-handler-registered path.

## Tests added — \`tests/test_v1_2_811_fixes.py\`

6 regression tests:
- \`Body(List[Struct])\` happy path
- \`Body(List[Struct])\` validation error (422)
- \`Body(Optional[Struct])\` decoding
- \`exception_handler(HTTPException-subclass)\` invocation
- Plain HTTPException still uses default body when no handler is registered
- Explicit \`exception_handler(HTTPException)\` still wins over default

## Verification
- ✅ 366/367 tests pass with compiled \`.so\` loaded
- ✅ 366/367 tests pass with \`.so\` moved aside (pure-Python fallback)
- ✅ FULL HANDLER 1.03–1.11 µs, body POST 0.79–0.82 µs (within v1.2.81 noise)