### PR TITLE
fix(v1.2.812): example test runner — remove __init__.py + absolute imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.812] — 2026-05-22
+
+**Fix the example test runner.**  Companion to v1.2.811: brings `pytest example/tests/`
+back to a green collection so the v1.2.83 audit has a working baseline.
+
+### Fixed
+
+- **`example/tests/` collection** — pytest 8.x + `pytest-asyncio 0.23.x` raise
+  `AttributeError: 'Package' object has no attribute 'obj'` during collection
+  whenever any ancestor of the test file is a Python package. The framework's
+  own `tests/` directory has no `__init__.py` and so was unaffected; the
+  `example/` tree has `__init__.py` everywhere (for the relative imports in
+  the app code), so its tests never collected.
+
+  Two-part fix:
+  1. **Remove `example/tests/__init__.py`** — the test directory does not need
+     to be a sub-package of `example/`.  pytest discovers tests by file name,
+     not by package membership.
+  2. **Switch test-file imports from relative to absolute**: `from ..app import app`
+     → `from example.app import app` (and similarly for `..config`, `..modules.*`).
+     Affected files: `conftest.py`, `test_async_client.py`, `test_customers.py`,
+     `test_verification.py`. `test_auth.py` had no imports.
+
+- **`example/requirements.txt`** — bump `pytest-asyncio>=1.1.0` (was `>=0.23.0`).
+  The 0.23.x line carries the Package-collector bug; 1.1.0+ fixes it.
+  The framework's own `pyproject.toml` already requires `^1.1.0`.
+
+### Verified
+
+- `pytest example/tests/` now collects 17 tests and runs them; 16/17 pass.
+- The single remaining failure (`TestVerificationEndpoints.test_start_enhanced_verification`)
+  is a pre-existing domain-logic issue in the example: `VerificationService.start_verification`
+  reuses an in-progress verification when one already exists for the customer,
+  so the second test in the class re-uses the first test's `standard`
+  verification (3 checks) instead of creating an `enhanced` one (5 checks).
+  Tracked as a v1.2.83 audit finding — out of scope for the test-runner fix.
+- Framework suite still 366/367.
+
+---
+
 ## [1.2.811] — 2026-05-22
 
 **Framework bug fixes discovered during v1.2.81 example modernization.**

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -11,7 +11,7 @@ aiofiles>=23.0.0
 
 # Testing
 pytest>=8.0.0
-pytest-asyncio>=0.23.0
+pytest-asyncio>=1.1.0  # 0.23.x had a Package-collection bug breaking tests in subpackages
 httpx>=0.27.0
 
 # Development server

--- a/example/tests/__init__.py
+++ b/example/tests/__init__.py
@@ -1,3 +1,0 @@
-"""
-Tests for KYC Demo API.
-"""

--- a/example/tests/conftest.py
+++ b/example/tests/conftest.py
@@ -13,8 +13,8 @@ from datetime import datetime, timedelta
 
 from tachyon_api.testing import TachyonTestClient
 
-from ..app import app
-from ..config import settings
+from example.app import app
+from example.config import settings
 
 
 @pytest.fixture

--- a/example/tests/test_async_client.py
+++ b/example/tests/test_async_client.py
@@ -13,8 +13,8 @@ import pytest
 
 from tachyon_api.testing import create_client
 
-from ..app import app
-from ..config import settings
+from example.app import app
+from example.config import settings
 
 
 def _auth_headers() -> dict:

--- a/example/tests/test_customers.py
+++ b/example/tests/test_customers.py
@@ -4,9 +4,9 @@ Tests for Customers module.
 Demonstrates dependency_overrides for mocking.
 """
 
-from ..app import app
-from ..modules.customers.customers_repository import CustomersRepository
-from ..modules.customers.customers_dto import CustomerResponse, AddressDTO
+from example.app import app
+from example.modules.customers.customers_repository import CustomersRepository
+from example.modules.customers.customers_dto import CustomerResponse, AddressDTO
 
 
 class MockCustomersRepository:

--- a/example/tests/test_verification.py
+++ b/example/tests/test_verification.py
@@ -2,9 +2,9 @@
 Tests for Verification module.
 """
 
-from ..app import app
-from ..modules.customers.customers_repository import CustomersRepository
-from ..modules.customers.customers_dto import CustomerResponse
+from example.app import app
+from example.modules.customers.customers_repository import CustomersRepository
+from example.modules.customers.customers_dto import CustomerResponse
 
 
 class MockCustomersRepository:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.811"
+version = "1.2.812"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary — v1.2.812 (example test runner fix)

Brings \`pytest example/tests/\` back to a green collection so the v1.2.83 audit has a working baseline.  Companion to v1.2.811.

## Bug

pytest 8.x + \`pytest-asyncio 0.23.x\` raise
\`\`\`
AttributeError: 'Package' object has no attribute 'obj'
\`\`\`
during collection whenever any ancestor of the test file is a Python package.  The framework's own \`tests/\` has no \`__init__.py\` and so was unaffected; \`example/\` has \`__init__.py\` everywhere (for the relative imports in app code), so its tests **never** collected before this PR.

## Fix (two parts)

1. **Remove \`example/tests/__init__.py\`** — the test directory does not need to be a sub-package of \`example/\`.  pytest discovers tests by file name, not by package membership.
2. **Switch test-file imports from relative to absolute** (\`from ..app\` → \`from example.app\`) in: \`conftest.py\`, \`test_async_client.py\`, \`test_customers.py\`, \`test_verification.py\`.
3. **\`example/requirements.txt\`** — bump \`pytest-asyncio>=1.1.0\` (was \`>=0.23.0\`).  Framework \`pyproject.toml\` already requires \`^1.1.0\`.

## Verification
- ✅ \`pytest example/tests/\` collects 17 tests, **16 pass**
- ✅ Framework suite still 366/367
- ⚠️ The 1 example failure (\`test_start_enhanced_verification\`) is a pre-existing domain-logic issue: \`VerificationService.start_verification\` reuses an in-progress verification when one already exists, so the second test in the class re-uses the first test's "standard" verification (3 checks) instead of creating an "enhanced" one (5 checks).  **Tracked as v1.2.83 audit finding — out of scope here.**