### PR TITLE
refactor(v1.2.813): remove example workarounds — use v1.2.811 features directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.813] — 2026-05-22
+
+**Remove example workarounds now that v1.2.811 fixed the underlying framework
+bugs.** The example now showcases the v1.2.0 features *directly* — no
+wrappers, no internal dispatch tricks.
+
+### Reverted (example only)
+
+- **`modules/customers/customers_controller.py::bulk_create_customers`** —
+  parameter restored to `customers: List[CustomerCreate] = Body(...)`.
+  This was using a `BulkCreateRequest` wrapper as a workaround for the
+  decoder bug fixed in v1.2.811.
+
+- **`modules/customers/customers_dto.py`** — `BulkCreateRequest` Struct
+  removed. It existed only to sidestep the broken `Body(List[Struct])`
+  decoder and has no remaining use.
+
+- **`app.py::kyc_exception_handler`** — registered for `KYCException`
+  again (was registered for `HTTPException` as a workaround for the
+  dispatch bug fixed in v1.2.811). The handler body shrinks from a
+  two-branch `isinstance` dispatch to a single formatter for the
+  KYC hierarchy. `HTTPException` import removed.
+
+- **`README.md`** — "Known limitations" callout removed; the workaround
+  notes in the feature matrix are replaced with the direct-usage
+  descriptions. `⭐ = new or revised in Tachyon v1.2.x` (was v1.2.0,
+  now spans v1.2.811 too).
+
+### Verified
+
+- 366/367 framework tests pass (`pytest tests/`).
+- 16/17 example tests pass (`pytest example/tests/`). The single failure
+  is the pre-existing `test_start_enhanced_verification` cross-test
+  state issue tracked in v1.2.83 audit, unrelated to this PR.
+- End-to-end smoke (`TestClient`):
+  - `GET /customers/me` (no auth) → 401, body `{"code": "UNAUTHORIZED"}`
+    via the now-direct `@app.exception_handler(KYCException)`.
+  - `POST /customers/bulk` with a JSON array → 200, returns the array
+    via direct `Body(List[CustomerCreate])` decoding.
+  - OpenAPI: `/customers/bulk` requestBody schema =
+    `{"type": "array", "items": {"$ref": "#/components/schemas/CustomerCreate"}}`
+    (no wrapper Struct).
+
+---
+
 ## [1.2.812] — 2026-05-22
 
 **Fix the example test runner.**  Companion to v1.2.811: brings `pytest example/tests/`

--- a/example/README.md
+++ b/example/README.md
@@ -17,36 +17,21 @@ cycle so users coming from FastAPI can map idioms 1:1.
 | **JWT Authentication** | `modules/auth/` | Login, registration, token validation |
 | **API Key Auth** | `shared/dependencies.py` | Service-to-service auth |
 | **File Uploads (multipart)** | `modules/documents/` | `Form()` + `File()` → `multipart/form-data` in OpenAPI |
-| **Bulk request body** ⭐ v1.2.0 | `customers_controller.bulk_create_customers` | Nested `List[Struct]` inside a Struct body |
+| **Bulk request body** ⭐ v1.2.0 | `customers_controller.bulk_create_customers` | `Body(List[CustomerCreate])` — direct list body |
 | **`List[Struct]` response model** ⭐ v1.2.0 | `customers_controller.list_recent_customers` | `response_model=List[CustomerResponse]` → array schema |
 | **Background Tasks** | `modules/verification/` | Async verification processing |
 | **WebSockets — DI + typed path** ⭐ v1.2.0 | `modules/admin/admin_ws.py` | `room_id: uuid.UUID` + `Depends(AdminBroadcaster)` |
 | **WebSockets — legacy plain path** | `app.py` | Original customer-notification channel kept for compat |
 | **Security headers** ⭐ v1.2.0 | `app.py` | `SecurityHeadersMiddleware` registered explicitly |
 | **CORS opt-in** ⭐ v1.2.0 | `app.py` | Explicit `allow_origins` list (no more wildcard default) |
-| **Custom exception handler** | `app.py` | `@app.exception_handler(HTTPException)` with isinstance dispatch |
+| **Custom exception handler** ⭐ v1.2.811 | `app.py` | `@app.exception_handler(KYCException)` — subclasses of `HTTPException` are dispatched correctly |
 | **Caching** | `verification_service.py` | `@cache` decorator usage |
 | **Lifecycle Events** | `app.py` | `lifespan` context manager |
 | **Custom Exceptions** | `shared/exceptions.py` | Descriptive error hierarchy |
 | **Testing — sync** | `tests/conftest.py` | `TachyonTestClient`, `dependency_overrides` |
 | **Testing — async** ⭐ v1.2.0 | `tests/test_async_client.py` | `tachyon_api.testing.create_client` with httpx kwargs |
 
-⭐ = new or revised in Tachyon v1.2.0. Click through to the source for usage.
-
-> **Known limitations (v1.2.83 audit findings):**
-> - `Body(List[Struct])` directly fails at runtime — the OpenAPI spec is
->   generated correctly but the msgspec decoder is only configured for direct
->   Struct subclasses.  Workaround used here: wrap in a Struct (see
->   `BulkCreateRequest` in `customers_dto.py`).
-> - `@app.exception_handler(KYCException)` is not invoked — Tachyon's dispatch
->   currently only consults `HTTPException` as the catch-all for HTTPException
->   subclasses.  Workaround: register for `HTTPException` and dispatch by
->   `isinstance` inside the handler (see `app.py`).
-> - `pytest example/tests/` collection fails on pytest 8.x + pytest-asyncio
->   0.23.x (`'Package' object has no attribute 'obj'`).  All tests in this
->   directory are correct in content; the collection issue is structural.
-
-Both runtime gaps will be addressed in the v1.2.9 Cython sprint.
+⭐ = new or revised in Tachyon v1.2.x. Click through to the source for usage.
 
 ## 📁 Project Structure
 

--- a/example/app.py
+++ b/example/app.py
@@ -22,7 +22,7 @@ from contextlib import asynccontextmanager
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
-from tachyon_api import HTTPException, Tachyon
+from tachyon_api import Tachyon
 from tachyon_api.middlewares import (
     CORSMiddleware,
     LoggerMiddleware,
@@ -113,34 +113,24 @@ app.add_middleware(LoggerMiddleware)
 
 
 # ── Custom exception handler ──────────────────────────────────────────────────
-# NOTE: Tachyon's ExceptionTable.dispatch currently short-circuits to the
-# default response for any HTTPException unless a handler is registered for
-# `HTTPException` directly — handlers registered for HTTPException *subclasses*
-# (like our `KYCException`) are never invoked.  Tracked as a v1.2.83 audit
-# finding; the workaround below registers for `HTTPException` and dispatches
-# internally by isinstance.
 
-@app.exception_handler(HTTPException)
-async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+@app.exception_handler(KYCException)
+async def kyc_exception_handler(request: Request, exc: KYCException) -> JSONResponse:
     """
-    Catches every HTTPException raised by the app and formats it consistently.
+    Single handler for the whole KYCException hierarchy.
 
-    For our domain exceptions (KYCException subclasses), we emit the
-    `error_code` so clients can branch on a stable identifier.  Generic
-    HTTPExceptions get a plain `detail` body.
+    Translates the domain-specific `error_code` into the response body while
+    preserving the HTTP status code declared by the exception.  Other HTTPException
+    types raised by the framework fall through to Tachyon's default
+    `{"detail": ...}` response.
     """
-    if isinstance(exc, KYCException):
-        return JSONResponse(
-            status_code=exc.status_code,
-            content={
-                "success": False,
-                "error": exc.detail,
-                "code": getattr(exc, "error_code", "KYC_ERROR"),
-            },
-        )
     return JSONResponse(
         status_code=exc.status_code,
-        content={"success": False, "error": exc.detail, "code": "HTTP_ERROR"},
+        content={
+            "success": False,
+            "error": exc.detail,
+            "code": getattr(exc, "error_code", "KYC_ERROR"),
+        },
     )
 
 

--- a/example/modules/customers/customers_controller.py
+++ b/example/modules/customers/customers_controller.py
@@ -21,7 +21,6 @@ from ...shared.id_generator import IdGenerator
 from ...shared.request_context import RequestContext
 from .customers_service import CustomersService
 from .customers_dto import (
-    BulkCreateRequest,
     CustomerCreate,
     CustomerUpdate,
     CustomerResponse,
@@ -147,7 +146,7 @@ def delete_customer(
 
 @router.post("/bulk", response_model=List[CustomerResponse])
 def bulk_create_customers(
-    payload: BulkCreateRequest = Body(...),
+    customers: List[CustomerCreate] = Body(...),
     user: dict = Depends(get_current_user),
     service: CustomersService = Depends(),
     ctx: RequestContext = Depends(),     # request-scoped — same instance for whole request
@@ -157,16 +156,16 @@ def bulk_create_customers(
     Bulk-create multiple customer profiles in a single request.
 
     Showcases:
-    - Nested `List[CustomerCreate]` inside a Struct body → array property in OpenAPI
+    - `Body(List[CustomerCreate])` → `array` request body in OpenAPI + runtime decode
     - `response_model=List[CustomerResponse]` → array response schema
     - `@injectable(scope="request")` RequestContext for correlation tracking
     - `@injectable(scope="transient")` IdGenerator (a fresh sequence per call)
     """
     ctx.set("operation", "bulk_create")
-    ctx.set("count", len(payload.customers))
+    ctx.set("count", len(customers))
 
     results: List[CustomerResponse] = []
-    for data in payload.customers:
+    for data in customers:
         batch_id = id_gen.next_id()
         created = service.create_customer(user["user_id"], data)
         created.customer_id = f"{batch_id}-{created.customer_id}"

--- a/example/modules/customers/customers_dto.py
+++ b/example/modules/customers/customers_dto.py
@@ -60,16 +60,3 @@ class CustomerListResponse(Struct):
     total: int
     page: int
     limit: int
-
-
-class BulkCreateRequest(Struct):
-    """
-    Bulk create request wrapper.
-
-    NOTE: this wrapper exists because Tachyon's Body decoder currently only
-    sets up msgspec for direct Struct subclasses — `Body(List[Struct])` works
-    in the OpenAPI spec but fails at runtime decode (v1.2.83 audit finding).
-    Wrapping the list in a Struct sidesteps the limitation.
-    """
-
-    customers: List[CustomerCreate]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.812"
+version = "1.2.813"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary — v1.2.813 (closes the v1.2.81 + v1.2.811 + v1.2.812 micro-sequence)

Now that v1.2.811 fixed the underlying framework bugs, the example can
showcase the v1.2.0 features **directly** instead of through the workarounds
added in v1.2.81.

## Reverted (example only)

| Workaround → direct usage |
|---|
| \`bulk_create_customers(payload: BulkCreateRequest = Body(...))\` → \`customers: List[CustomerCreate] = Body(...)\` |
| \`BulkCreateRequest\` Struct (existed only to wrap the list) → **removed** |
| \`@app.exception_handler(HTTPException)\` with internal \`isinstance(exc, KYCException)\` branching → \`@app.exception_handler(KYCException)\` |
| README "Known limitations" callout → **removed** (limitations are now fixed) |

## Verification

- ✅ 366/367 framework tests
- ✅ 16/17 example tests (the 1 failure is the pre-existing cross-test state issue in \`test_start_enhanced_verification\`, tracked in v1.2.83 audit)
- ✅ Smoke (\`TestClient\`):
  - \`GET /customers/me\` (no auth) → 401 \`{"code": "UNAUTHORIZED"}\` via direct \`@app.exception_handler(KYCException)\`
  - \`POST /customers/bulk [...]\` (JSON array body) → 200, 2 customers returned via direct \`Body(List[CustomerCreate])\`
  - OpenAPI: \`/customers/bulk\` request body =
    \`{"type": "array", "items": {"$ref": "#/components/schemas/CustomerCreate"}}\` (no wrapper)