### PR TITLE
docs(v1.2.82): refresh README + docs/ for v1.2.x state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.82] — 2026-05-22
+
+**v1.2.8x project audit / Cython prep — sub-version 2/4: refresh README + docs/.**
+No framework code changes.  Brings the public documentation in line with everything
+that landed during v1.2.x, including the SRP refactor and the v1.2.811 fixes.
+
+### Documentation (docs only)
+
+- **`README.md`**:
+  - Version badge `1.1.0` → `1.2.x`; tests badge `233` → `366 passed`.
+  - Feature matrix expanded with DI scopes, WebSocket DI + typed paths,
+    `Body(List[Struct])`, `SecurityHeadersMiddleware`, async `create_client`,
+    and a new "Architecture" row pointing at the 63-module SRP layout.
+  - New top-level **Architecture** section with an ASCII flow diagram of the
+    request hot path (`Tachyon.__call__ → ASGIEntry → HTTPDispatcher →
+    TachyonDispatcher → handler closure → response`).
+  - DI snippet shows all three scopes (`singleton`, `request`, `transient`).
+  - WebSocket snippet uses typed `room_id: uuid.UUID` and an injected
+    `RoomBroadcaster`.
+  - Testing snippet shows the modern `create_client` async pattern.
+  - KYC demo summary updated (17 tests, async tests, exception handler).
+  - Docs table adds a link to the new `16-cython-build.md`.
+
+- **`docs/README.md`** (index): version `0.7.0` → `1.2.x`, "Why Tachyon?" table
+  expanded with routing, DI scopes, OpenAPI capabilities. New entry for
+  `16-cython-build.md`.
+
+- **`docs/02-architecture.md`**: appended a *Tachyon's Internal Architecture*
+  section enumerating the 63 SRP modules across `app/`, `processing/`,
+  `responses/`, `openapi/`, `security/`, and which paths are hot vs cold.
+
+- **`docs/03-dependency-injection.md`**: new section on **scopes** with the
+  decision matrix (singleton / request / transient); explicit notes on async
+  `Depends` and the v1.2.811 `exception_handler` subclass dispatch fix;
+  summary table updated.
+
+- **`docs/10-websockets.md`**: new sections **Typed Path Params** (UUID
+  auto-conversion + 1008 on mismatch) and **DI in WebSocket handlers** (covers
+  `@injectable` and `Depends(callable)` per-connection).
+
+- **`docs/11-testing.md`**: `create_client()` documented as the canonical
+  async helper with the full set of httpx kwargs (`headers`, `cookies`,
+  `auth`, `follow_redirects`, `timeout`); `AsyncTachyonTestClient` kept as the
+  class-based equivalent.
+
+- **`docs/14-migration-fastapi.md`**: new **v1.2.x Gotchas** section
+  covering CORS opt-in, `max_body_size` default 2 MB, `SecurityHeadersMiddleware`
+  opt-in, sanitized `UploadFile.filename`, and the v1.2.811 exception-handler
+  subclass dispatch. `@injectable` paragraph mentions the three scopes;
+  async-test example now uses `create_client`.
+
+### Added (docs only)
+
+- **`docs/16-cython-build.md`** (new): when and how to compile `[fast]`.
+  Covers `pip install tachyon-api[fast]` + `python setup.py build_ext --inplace`,
+  the list of compiled extensions, fallback behavior, expected perf delta,
+  compiler-flag overrides, troubleshooting, and forward reference to the
+  v1.2.9 Cython sprint roadmap.
+
+### Verification
+
+- 366/367 framework tests pass (unchanged, no code touched).
+- 16/17 example tests pass (unchanged).
+- Documentation links validated by direct file existence (`docs/16-cython-build.md`).
+
+---
+
 ## [1.2.813] — 2026-05-22
 
 **Remove example workarounds now that v1.2.811 fixed the underlying framework

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # 🚀 Tachyon API
 
-![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)
+![Version](https://img.shields.io/badge/version-1.2.x-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.10+-brightgreen.svg)
 ![License](https://img.shields.io/badge/license-GPL--3.0-orange.svg)
-![Tests](https://img.shields.io/badge/tests-233%20passed-brightgreen.svg)
+![Tests](https://img.shields.io/badge/tests-366%20passed-brightgreen.svg)
 ![Status](https://img.shields.io/badge/status-stable-brightgreen.svg)
 
 **A lightweight, high-performance API framework for Python with the elegance of FastAPI and the speed of light.**
@@ -95,15 +95,16 @@ python setup.py build_ext --inplace    # compile extensions (required step)
 | Category | Features |
 |----------|----------|
 | **Core** | Decorators API, Routers, Middlewares, ASGI compatible |
-| **Parameters** | Path, Query, Body, Header, Cookie, Form, File (all with `alias=`) |
-| **Validation** | msgspec Struct (ultra-fast), automatic 422 errors, body size limit |
-| **DI** | `@injectable` (implicit), `Depends()` (explicit), circular dep detection |
-| **Security** | HTTPBearer, HTTPBasic, OAuth2, API Keys |
-| **Async** | Background Tasks, WebSockets |
-| **Performance** | orjson serialization, `@cache` decorator, endpoint pre-compilation |
-| **Docs** | OpenAPI 3.0, Scalar UI, Swagger, ReDoc (XSS-safe HTML generation) |
-| **CLI** | Project scaffolding, code generation, linting |
-| **Testing** | `TachyonTestClient`, `dependency_overrides` |
+| **Parameters** | Path, Query, Body (incl. `Body(List[Struct])`), Header, Cookie, Form, File (all with `alias=`) |
+| **Validation** | msgspec Struct (ultra-fast), automatic 422 errors, configurable body size limit (default 2 MB) |
+| **DI** | `@injectable` (3 scopes: singleton / **request** / **transient**), `Depends()` (sync + async), circular dep detection |
+| **Security** | HTTPBearer, HTTPBasic, OAuth2, API Keys (Header / Query / Cookie), `SecurityHeadersMiddleware` (X-Frame-Options, CSP, HSTS, …) |
+| **Async** | Background Tasks (failures logged, not silenced), WebSockets with **typed path params + DI** |
+| **Performance** | orjson serialization, `@cache` decorator, endpoint pre-compilation, optional Cython hot-path |
+| **Docs** | OpenAPI 3.0 (incl. `List[Struct]` arrays + `multipart/form-data`), Scalar UI, Swagger, ReDoc (XSS-safe HTML generation) |
+| **CLI** | Project scaffolding, code generation, linting, AI-agent skill installer |
+| **Testing** | `TachyonTestClient` (sync), `create_client()` (async, full httpx kwargs), `dependency_overrides` |
+| **Architecture** | 63 atomic SRP modules across `app/`, `processing/`, `responses/`, `openapi/`, `security/` (v1.2.x refactor) |
 
 ---
 
@@ -126,6 +127,7 @@ python setup.py build_ext --inplace    # compile extensions (required step)
 | [Request Lifecycle](./docs/13-request-lifecycle.md) | How requests are processed |
 | [Migration from FastAPI](./docs/14-migration-fastapi.md) | Migration guide |
 | [Best Practices](./docs/15-best-practices.md) | Recommended patterns |
+| [Cython Build](./docs/16-cython-build.md) | Compiling `[fast]` extensions |
 
 ---
 
@@ -139,13 +141,16 @@ pip install -r requirements.txt
 uvicorn example.app:app --reload
 ```
 
-The KYC Demo implements:
-- 🔐 JWT Authentication
-- 👤 Customer CRUD
+The KYC Demo exercises every v1.2.x feature:
+- 🔐 JWT Authentication + API Keys
+- 👤 Customer CRUD + bulk endpoint (`Body(List[Struct])`)
 - 📋 KYC Verification with Background Tasks
-- 📁 Document Uploads
-- 🌐 WebSocket Notifications
-- 🧪 12 Tests with Mocks
+- 📁 Document Uploads (`multipart/form-data`)
+- 🌐 WebSocket — legacy plain-string + modern DI-injected with `room_id: uuid.UUID`
+- 💉 DI scopes — `singleton` (services), `request` (correlation context), `transient` (ID generator)
+- 🛡️ Security headers + opt-in CORS allow-list
+- 🚨 Custom exception handler for the `KYCException` hierarchy
+- 🧪 17 tests (`pytest example/tests/`), including async tests via `create_client`
 
 **Demo credentials:** `demo@example.com` / `demo123`
 
@@ -164,19 +169,69 @@ The KYC Demo implements:
 
 ---
 
+## 🏛️ Architecture
+
+Tachyon's request hot path is a thin chain of composed collaborators — every
+piece is single-responsibility and ready for Cython compilation:
+
+```
+client
+  │
+  ├─→ Tachyon.__call__ (ASGI entry — sets scope["app"])
+  │     │
+  │     ├─→ ASGIEntry         lazy build of HTTP app
+  │     │
+  │     ├─→ HTTPDispatcher    HTTP → trie  ·  WS/lifespan → Starlette
+  │     │
+  │     ├─→ MiddlewareStack   user-registered middlewares (CORS, Security…)
+  │     │
+  │     └─→ TachyonDispatcher (Cython cdef)  ← radix trie match O(k)
+  │           │
+  │           ├─→ _ASGIHandler (no-param fast path, 2 sends only)
+  │           │
+  │           └─→ handler closure
+  │                 ├─→ ParameterPipeline → 10 atomic extractors
+  │                 │     (body / query / query-list / header / cookie / form / file / path)
+  │                 ├─→ DependencyResolver → OverrideLookup / ScopeCache /
+  │                 │                        ClassFactory / CallableFactory
+  │                 ├─→ ResponseProcessor (msgspec encode if Struct)
+  │                 └─→ ExceptionTable (walks subclass handlers)
+  │
+  └─→ TachyonJSONResponse | TachyonBytesResponse | _InternalErrorResponse
+        (pre-built ASGI dicts, zero extra allocations per response)
+```
+
+The v1.2.x SRP refactor decomposed 1,753 monolithic lines into 63 atomic modules
+with `__slots__` and full type hints — direct `cdef class` candidates.
+
+👉 [Full architecture documentation](./docs/02-architecture.md)
+
+---
+
 ## 💉 Dependency Injection
 
 ```python
 from tachyon_api import injectable, Depends
 
-@injectable
-class UserService:
-    def get_user(self, id: str):
-        return {"id": id}
+@injectable                       # singleton (default) — one per app
+class DB:
+    def __init__(self):
+        self.pool = "..."
+
+@injectable(scope="request")      # one per HTTP request
+class RequestContext:
+    def __init__(self):
+        import uuid
+        self.correlation_id = str(uuid.uuid4())
+
+@injectable(scope="transient")    # new instance every time it's injected
+class IdGenerator:
+    def __init__(self):
+        self._seq = 0
 
 @app.get("/users/{id}")
-def get_user(id: str, service: UserService = Depends()):
-    return service.get_user(id)
+def get_user(id: str, db: DB = Depends(), ctx: RequestContext = Depends()):
+    return {"id": id, "trace": ctx.correlation_id}
 ```
 
 👉 [Full DI documentation](./docs/03-dependency-injection.md)
@@ -217,11 +272,22 @@ def notify(background_tasks: BackgroundTasks):
 ## 🌐 WebSockets
 
 ```python
-@app.websocket("/ws")
-async def websocket(ws):
-    await ws.accept()
-    data = await ws.receive_text()
-    await ws.send_text(f"Echo: {data}")
+import uuid
+from tachyon_api import injectable, Depends
+
+@injectable
+class RoomBroadcaster:
+    async def join(self, ws, room_key: str): ...
+
+@app.websocket("/ws/rooms/{room_id}")           # typed UUID path param
+async def room(
+    websocket,
+    room_id: uuid.UUID,                          # auto-converted; 1008 on mismatch
+    broadcaster: RoomBroadcaster = Depends(),    # @injectable DI in WS
+):
+    await broadcaster.join(websocket, str(room_id))
+    while True:
+        await websocket.send_json({"room": str(room_id)})
 ```
 
 👉 [Full WebSockets documentation](./docs/10-websockets.md)
@@ -272,12 +338,23 @@ Installs knowledge about `Body()` requirement, `Struct` vs BaseModel, DI pattern
 ## 🧪 Testing
 
 ```python
+# Sync — Starlette TestClient compatible
 from tachyon_api.testing import TachyonTestClient
 
 def test_hello():
     client = TachyonTestClient(app)
-    response = client.get("/")
-    assert response.status_code == 200
+    assert client.get("/").status_code == 200
+
+
+# Async — httpx.AsyncClient over ASGI transport
+import pytest
+from tachyon_api.testing import create_client
+
+@pytest.mark.asyncio
+async def test_hello_async():
+    async with create_client(app, headers={"X-Trace": "abc"}) as client:
+        response = await client.get("/")
+        assert response.status_code == 200
 ```
 
 ```bash

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -201,7 +201,93 @@ Esto crea automáticamente:
 
 ---
 
+## 🧩 Tachyon's Internal Architecture (v1.2.x SRP refactor)
+
+Tu *application* sigue el layout de arriba.  El **framework mismo** está
+organizado por SRP — 63 módulos atómicos repartidos en paquetes con una
+responsabilidad por archivo.  Cada pieza es candidata directa a `cdef class`
+en v1.2.9.
+
+```
+tachyon_api/
+├── app/                       # ASGI surface + composed collaborators
+│   ├── __init__.py            # Tachyon facade (composes the rest)
+│   ├── _asgi_entry.py         # __call__ — lazy HTTP-app build
+│   ├── _http_dispatch.py      # HTTPDispatcher (HTTP vs WS/lifespan)
+│   ├── _mw_stack.py           # MiddlewareStack
+│   ├── _registry.py           # RouteRegistry
+│   ├── _exception_table.py    # ExceptionTable (walks subclass handlers)
+│   ├── _handler_factory.py    # closure for endpoints with params
+│   ├── _fast_asgi_factory.py  # closure for no-param endpoints
+│   ├── _route_installer.py    # trie + registry + openapi orchestration
+│   ├── _docs_routes.py        # registers /docs /redoc /swagger /openapi.json
+│   ├── _docs_schemas.py       # CommonSchemas (default error schemas)
+│   ├── _asgi_handler.py       # _ASGIHandler marker (fast-path tag)
+│   └── _404.py, _405.py       # pre-built ASGI constants
+│
+├── processing/                # request hot path
+│   ├── compiler.py + .pyx     # endpoint pre-compilation
+│   ├── parameters.py + .pyx   # ParameterPipeline orchestrator
+│   ├── _extractors/           # 10 single-responsibility extractors
+│   │   ├── body.py, body_limit.py, query.py, query_list.py,
+│   │   ├── header.py, cookie.py, form.py, file.py, path.py,
+│   │   ├── _base.py (ExtractorResult), _missing.py
+│   ├── dependencies/          # DI pipeline (7 atomic pieces)
+│   │   ├── _resolver.py, _override_lookup.py, _scope_cache.py,
+│   │   ├── _circular_detector.py, _class_factory.py,
+│   │   ├── _callable_factory.py, _sig_cache.py
+│   ├── response_processor.py + .pyx
+│   ├── scope.py + .pyx        # TachyonScope (lazy Starlette Request)
+│   └── dispatch.py + .pyx     # TachyonDispatcher (cdef class)
+│
+├── responses/                 # response classes + caches + wire constants
+│   ├── _json_response.py      # TachyonJSONResponse
+│   ├── _bytes_response.py     # TachyonBytesResponse
+│   ├── _internal_error.py     # _InternalErrorResponse singleton
+│   ├── _caches.py             # _CL_CACHE, _CT_TUPLE precomputed
+│   ├── _wire.py               # HTTP/1.1 wire bytes (TachyonServer path)
+│   ├── _success.py, _error.py, _validation.py
+│   └── _constants.py          # ASGI message-type strings, header bytes
+│
+├── openapi/                   # OpenAPI spec + 3 HTML renderers
+│   ├── _generator.py, _route_builder.py
+│   ├── _struct_schemas.py, _param_schemas.py
+│   ├── _config.py, _factory.py, _info.py, _server.py
+│   ├── _format_map.py, _safe_json.py
+│   └── _swagger_html.py, _redoc_html.py, _scalar_html.py
+│
+├── security/                  # 4 auth schemes + value objects
+│   ├── _http_bearer.py, _http_basic.py
+│   ├── _api_key_header.py, _api_key_query.py, _api_key_cookie.py
+│   ├── _oauth2_bearer.py
+│   ├── _bearer_credentials.py, _basic_credentials.py
+│   └── _bearer_parser.py, _api_key_base.py
+│
+├── routing/trie.py + .pyx     # radix trie router (Cython cdef)
+├── core/lifecycle.py + websocket.py
+├── middlewares/ (CORS, Logger, SecurityHeaders)
+├── di.py                      # Depends + injectable + scope registries
+├── models.py, params.py, exceptions.py, files.py, cache.py, background.py
+├── _server_fast.pyx           # direct transport.write() fast path
+└── cli/                       # commands + templates
+```
+
+**Hot path** = touched per HTTP request:
+`Tachyon.__call__` → `ASGIEntry` → `HTTPDispatcher` → `TachyonDispatcher` (Cython) →
+`ParameterPipeline` → `DependencyResolver` → `ResponseProcessor` →
+`TachyonJSONResponse` / `TachyonBytesResponse`.
+
+**Cold path** = touched at startup only:
+`RouteInstaller`, `DocsRoutes`, `OpenAPIGenerator`, every class in `openapi/` and
+`security/`, CLI.
+
+Every hot-path class declares `__slots__` and every method has full type hints —
+no import from the cold path into the hot path (verified in v1.2.7).
+
+---
+
 ## 🔗 Próximos Pasos
 
 - [Dependency Injection](./03-dependency-injection.md) - Cómo funciona `@injectable`
 - [Parameters](./04-parameters.md) - Tipos de parámetros
+- [Cython Build](./16-cython-build.md) - Compilar el hot path

--- a/docs/03-dependency-injection.md
+++ b/docs/03-dependency-injection.md
@@ -6,8 +6,8 @@
 
 Tachyon soporta dos tipos de inyección de dependencias:
 
-1. **Implícita** - Con `@injectable` (singleton)
-2. **Explícita** - Con `Depends()` (por request)
+1. **Implícita** - Con `@injectable` (tres scopes: `singleton`, `request`, `transient`)
+2. **Explícita** - Con `Depends()` (factory por request, sync + async)
 
 ---
 
@@ -42,9 +42,48 @@ def get_users(repo: UserRepository = Depends()):
 ```
 
 ### Características:
-- ✅ **Singleton** - Una instancia por aplicación
 - ✅ **Recursivo** - Resuelve dependencias anidadas
 - ✅ **Lazy** - Se crea cuando se necesita
+- ✅ **Cycle detection** - levanta `TypeError: Circular dependency detected ...`
+- ✅ **Scopes** - `singleton` (default), `request`, `transient` — ver sección siguiente
+
+---
+
+## 🔁 Scopes (v1.2.0+)
+
+`@injectable` acepta un keyword `scope` con tres valores:
+
+```python
+from tachyon_api import injectable
+
+@injectable                           # equivalente a @injectable(scope="singleton")
+class DB:
+    """One instance per application — shared across all requests."""
+
+@injectable(scope="request")
+class RequestContext:
+    """One instance per HTTP request — cached in the request's dependency_cache."""
+    def __init__(self):
+        import uuid
+        self.correlation_id = str(uuid.uuid4())
+
+@injectable(scope="transient")
+class IdGenerator:
+    """New instance on every injection — never cached."""
+    def __init__(self):
+        self._seq = 0
+```
+
+### Cuándo usar cada uno
+
+| Scope | Cuándo usarlo | Ejemplos |
+|-------|---------------|----------|
+| **`singleton`** *(default)* | Estado app-wide, conexiones costosas | DB pool, settings, HTTP clients, caches |
+| **`request`** | Estado por-request compartido entre deps | Correlation IDs, parsed auth claims, per-request feature flags |
+| **`transient`** | Builders / generadores que no deben compartir estado | UUID/ID generators, BulkRequestBuilder, EmailComposer |
+
+Sub-deps respetan el scope del padre: si `B` depende de `A` (request-scoped),
+`B.a` es **la misma instancia** que recibe el endpoint cuando depende de `A`.
 
 ---
 
@@ -78,7 +117,63 @@ def get_profile(user: dict = Depends(get_current_user)):
 ### Características:
 - ✅ **Por request** - Se ejecuta en cada request
 - ✅ **Cacheable** - Mismo callable = mismo resultado por request
-- ✅ **Async** - Soporta funciones async
+- ✅ **Async-aware** - Si el factory devuelve una coroutine, Tachyon la awaitea
+
+### Async dependencies
+
+`Depends(async_fn)` funciona transparentemente:
+
+```python
+async def get_user(token: str = Header(...)):
+    return await verify_token_async(token)
+
+@app.get("/me")
+async def me(user: dict = Depends(get_user)):   # await automático
+    return user
+```
+
+> **Limitación actual:** generator-based deps con `yield` para cleanup NO están
+> soportados.  Para cleanup, usá un context manager dentro del endpoint o
+> registralo en el lifespan.
+
+---
+
+## 🚨 Exception handlers para clases derivadas de HTTPException (v1.2.811+)
+
+Podés registrar handlers para SUBCLASES de `HTTPException` y Tachyon
+los va a despachar correctamente:
+
+```python
+from tachyon_api import Tachyon, HTTPException
+from starlette.responses import JSONResponse
+
+class KYCException(HTTPException):
+    def __init__(self, status_code, detail, error_code):
+        super().__init__(status_code=status_code, detail=detail)
+        self.error_code = error_code
+
+class CustomerNotFoundError(KYCException):
+    def __init__(self, customer_id):
+        super().__init__(404, f"Customer {customer_id} not found", "CUSTOMER_NOT_FOUND")
+
+app = Tachyon()
+
+@app.exception_handler(KYCException)        # captura todas las subclases
+async def kyc_handler(request, exc):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"success": False, "error": exc.detail, "code": exc.error_code},
+    )
+```
+
+`ExceptionTable.dispatch` itera los handlers registrados en orden de
+inserción y elige el primer `isinstance` match.  Si nada matchea pero
+la excepción ES `HTTPException`, vuelve al body default `{"detail": ...}`.
+
+Antes de v1.2.811 este handler nunca se ejecutaba: la dispatch hacía
+short-circuit al default response apenas veía un HTTPException.  Si
+estás migrando desde una versión anterior, los handlers para subclases
+ahora SÍ disparan — ojo con cambios de body shape.
 
 ---
 
@@ -210,8 +305,10 @@ def protected(user: dict = Depends(get_current_user)):
 
 | Tipo | Decorador/Función | Scope | Uso |
 |------|-------------------|-------|-----|
-| Implícita | `@injectable` | Singleton | Services, Repositories |
-| Explícita | `Depends(callable)` | Per-request | Auth, Factories |
+| Implícita | `@injectable` | Singleton *(default)* | Services, Repositories, DB pools |
+| Implícita | `@injectable(scope="request")` | Per-request | Correlation IDs, parsed auth context |
+| Implícita | `@injectable(scope="transient")` | New per injection | Builders, ID generators |
+| Explícita | `Depends(callable)` | Per-request | Auth, Factories, sync + async |
 | Override | `app.dependency_overrides` | Testing | Mocks |
 
 ---

--- a/docs/10-websockets.md
+++ b/docs/10-websockets.md
@@ -76,6 +76,79 @@ const ws = new WebSocket("ws://localhost:8000/ws/lobby");
 
 ---
 
+## 🎯 Typed Path Params (v1.2.0+)
+
+Anotá los path params con un tipo concreto y Tachyon parsea + valida antes
+de invocar el handler. Si la conversión falla, la conexión se cierra con
+código **1008 (policy violation)** y el handler no corre:
+
+```python
+import uuid
+
+@app.websocket("/ws/rooms/{room_id}")
+async def room(websocket, room_id: uuid.UUID):    # <- typed
+    # Si room_id no es un UUID válido, la conexión se cerró antes de llegar acá.
+    await websocket.accept()
+    await websocket.send_json({"room": str(room_id)})
+```
+
+Tipos soportados: `int`, `float`, `bool`, `str` *(default)*, `uuid.UUID`,
+`datetime`, `date`, y todo lo que `TypeConverter` resuelve para path params HTTP.
+
+---
+
+## 💉 DI en WebSocket handlers (v1.2.0+)
+
+Las mismas reglas de DI de los HTTP handlers aplican a los WebSockets — incluyendo
+`@injectable` (con sus tres scopes) y `Depends(callable)`:
+
+```python
+from tachyon_api import injectable, Depends
+
+@injectable                                       # singleton
+class RoomBroadcaster:
+    def __init__(self):
+        self._rooms: dict = {}
+
+    async def join(self, ws, key: str):
+        await ws.accept()
+        self._rooms.setdefault(key, []).append(ws)
+
+    async def broadcast(self, key: str, msg: dict):
+        for ws in self._rooms.get(key, []):
+            await ws.send_json(msg)
+
+async def get_optional_user(websocket):
+    """Factory que extrae usuario (o None) antes de aceptar la conexión."""
+    token = websocket.query_params.get("token")
+    return verify(token) if token else None
+
+@app.websocket("/ws/rooms/{room_id}")
+async def room_stream(
+    websocket,
+    room_id: uuid.UUID,
+    broadcaster: RoomBroadcaster = Depends(),         # @injectable singleton
+    user: dict = Depends(get_optional_user),          # callable per-connection
+):
+    await broadcaster.join(websocket, str(room_id))
+    while True:
+        data = await websocket.receive_json()
+        await broadcaster.broadcast(str(room_id), data)
+```
+
+### Cómo se resuelven los deps
+
+- **Descriptores pre-computados al registrar** la ruta (cero `inspect` por conexión).
+- **`@injectable` (singleton)**: misma instancia que comparte con el resto de la app.
+- **`Depends(callable)`**: se invoca **una vez por conexión** durante el setup
+  del handler, no por cada `receive` / `send`.
+
+> Limitación actual: la inyección de `request: Request` dentro de `Depends(callable)`
+> recibe el objeto `WebSocket` cuando el handler es WS — algunos factories diseñados
+> exclusivamente para HTTP pueden fallar al acceder `request.method`, etc.
+
+---
+
 ## ❓ Query Parameters
 
 ```python

--- a/docs/11-testing.md
+++ b/docs/11-testing.md
@@ -27,20 +27,55 @@ def test_hello():
 
 ---
 
-## 🔄 AsyncTachyonTestClient
+## 🔄 Async clients
 
-Para tests async:
+Tachyon expone dos formas equivalentes de testear async — ambas montan
+`httpx.AsyncClient` sobre `ASGITransport(app=app)`, sin red real:
+
+### `create_client()` *(recomendado — v1.2.0+)*
+
+Async context manager que devuelve directamente el `httpx.AsyncClient`,
+acepta cualquier kwarg de httpx:
 
 ```python
 import pytest
-from tachyon_api.testing import AsyncTachyonTestClient
+from tachyon_api.testing import create_client
 
 @pytest.mark.asyncio
 async def test_async_endpoint():
-    async with AsyncTachyonTestClient(app) as client:
+    async with create_client(app) as client:
         response = await client.get("/hello")
         assert response.status_code == 200
+
+@pytest.mark.asyncio
+async def test_with_kwargs():
+    async with create_client(
+        app,
+        headers={"X-Trace-Id": "abc"},
+        cookies={"session": "s123"},
+        auth=("user", "pass"),
+        follow_redirects=True,
+        timeout=10.0,
+    ) as client:
+        # Todos los kwargs son los de httpx.AsyncClient — base_url ya está seteado
+        r = await client.get("/me")
 ```
+
+### `AsyncTachyonTestClient`
+
+Equivalente clase-based, mismas opciones:
+
+```python
+from tachyon_api.testing import AsyncTachyonTestClient
+
+@pytest.mark.asyncio
+async def test_async():
+    async with AsyncTachyonTestClient(app, headers={"X-Token": "test"}) as client:
+        response = await client.get("/users/1")
+```
+
+Cuál elegir es preferencia de estilo — `create_client` es el helper canónico
+y el que usa la suite del framework + el example.
 
 ---
 

--- a/docs/14-migration-fastapi.md
+++ b/docs/14-migration-fastapi.md
@@ -133,9 +133,85 @@ def get_data(db: Database = Depends(get_db)):  # Also works
 ```
 
 ### Key difference
-`@injectable` creates an app-scoped singleton (created once, reused across all requests).
-FastAPI's `Depends(get_db)` creates a new instance per request unless you add `@lru_cache`.
-Tachyon's approach is more efficient for stateless services.
+`@injectable` creates an app-scoped singleton by default (created once, reused
+across all requests).  FastAPI's `Depends(get_db)` creates a new instance per
+request unless you add `@lru_cache`.
+
+For finer control, Tachyon v1.2.0+ accepts a `scope` keyword:
+
+```python
+@injectable                          # default — one per app
+@injectable(scope="request")         # one per HTTP request (cached in dependency_cache)
+@injectable(scope="transient")       # new instance on every injection
+```
+
+See [Dependency Injection](./03-dependency-injection.md) for when to use each.
+
+---
+
+## 🚨 v1.2.x Gotchas (after first migration)
+
+Items to keep in mind if you migrate to v1.2.x specifically:
+
+### CORS is opt-in *(v1.2.0+)*
+
+The CORS middleware no longer defaults to `allow_origins=["*"]`.  You must pass
+an explicit allow-list, or no Access-Control-Allow-Origin header will be set
+and browsers will block cross-origin requests:
+
+```python
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "https://example.com"],   # explicit
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+    allow_headers=["Authorization", "Content-Type"],
+)
+```
+
+### Default `max_body_size` reduced to 2 MB *(v1.2.0+)*
+
+FastAPI doesn't enforce a body-size limit by default.  Tachyon v1.2.0 ships
+with a 2 MB cap (down from 10 MB).  Bodies larger than the cap return 422.
+Override per-app:
+
+```python
+app = Tachyon(max_body_size=10 * 1024 * 1024)   # 10 MB
+```
+
+### `SecurityHeadersMiddleware` is opt-in
+
+X-Frame-Options, X-Content-Type-Options, Referrer-Policy, etc. are **not**
+applied by default.  Register the middleware if you want them:
+
+```python
+from tachyon_api.middlewares import SecurityHeadersMiddleware
+
+app.add_middleware(SecurityHeadersMiddleware)   # safe defaults
+```
+
+### `UploadFile.filename` is sanitized *(v1.2.0+)*
+
+Tachyon strips directory components and null bytes from
+`UploadFile.filename` at construction.  If your FastAPI code relied on the
+original filename for nested storage paths, you'll get the basename only
+(this is the secure behavior — applications should never trust filenames
+from clients).
+
+### Exception handlers for HTTPException subclasses *(v1.2.811+)*
+
+You can register a handler for a subclass of `HTTPException` and it will be
+dispatched correctly:
+
+```python
+class MyDomainError(HTTPException): ...
+
+@app.exception_handler(MyDomainError)
+async def domain_handler(request, exc):
+    return JSONResponse(status_code=exc.status_code, content={...})
+```
+
+Before v1.2.811 this didn't work — only handlers registered for
+`HTTPException` exactly were invoked.
 
 ---
 
@@ -296,20 +372,21 @@ def test_api():
     assert response.status_code == 200
 ```
 
-For async tests, use `httpx.AsyncClient` with `ASGITransport`:
+For async tests, use the bundled `create_client` helper *(v1.2.0+)*:
+
 ```python
 import pytest
-import httpx
+from tachyon_api.testing import create_client
 
 @pytest.mark.asyncio
 async def test_async():
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app),
-        base_url="http://test"
-    ) as client:
+    async with create_client(app, headers={"X-Trace": "t"}) as client:
         r = await client.get("/")
     assert r.status_code == 200
 ```
+
+It's a thin wrapper around `httpx.AsyncClient(transport=ASGITransport(app=app), ...)`
+that forwards every httpx kwarg (cookies, auth, follow_redirects, timeout, …).
 
 ---
 

--- a/docs/16-cython-build.md
+++ b/docs/16-cython-build.md
@@ -1,0 +1,195 @@
+# 16. Cython Build
+
+> When and how to compile Tachyon's `[fast]` extensions.
+
+## TL;DR
+
+```bash
+pip install tachyon-api[fast]              # installs cython
+python setup.py build_ext --inplace        # compile .pyx → .so
+```
+
+That's it.  Python's import system automatically prefers the compiled `.so`
+modules over their `.py` siblings.  If you skip compilation (or the `.so`
+files aren't present), Tachyon transparently falls back to the pure-Python
+implementations.
+
+---
+
+## Why compile?
+
+Tachyon's hot path is dual-implemented: every `.pyx` (Cython) module has a
+matching `.py` (pure Python) version that produces identical output.  At
+runtime, **whichever wins the import takes precedence** — the compiled `.so`
+if compiled, otherwise the pure-Python `.py`.
+
+| Mode | When it runs | Throughput |
+|---|---|---|
+| **Pure Python** *(no compilation)* | Development, CI without `[fast]`, environments without a C toolchain | Baseline (~5x FastAPI on the published benchmarks) |
+| **Compiled Cython** *(`[fast]` + `build_ext --inplace`)* | Production with toolchain | +5–11% on the hot path, larger gains on parameter-heavy endpoints |
+
+The published benchmarks in the main README are run **with** Cython compiled.
+The numbers in `benchmark/profile_hotpath.py` cycle around **1.05 µs FULL
+HANDLER** in compiled mode, **~1.20 µs** in pure-Python mode (~13% slower).
+
+---
+
+## What gets compiled
+
+The setup builds these extensions (see `setup.py` for the canonical list):
+
+| Source | Compiled extension | Role |
+|---|---|---|
+| `routing/trie.pyx` | `routing/trie.cpython-*.so` | Radix trie router (O(k) path match) |
+| `processing/compiler.pyx` | `processing/compiler.cpython-*.so` | Endpoint pre-compilation (`ParamDescriptor`, `CompiledEndpoint`) |
+| `processing/parameters.pyx` | `processing/parameters.cpython-*.so` | `ParameterProcessor` runtime extraction |
+| `processing/response_processor.pyx` | `processing/response_processor.cpython-*.so` | Response encoding + validation |
+| `processing/scope.pyx` | `processing/scope.cpython-*.so` | `TachyonScope` (lazy Starlette Request) |
+| `processing/dispatch.pyx` | `processing/dispatch.cpython-*.so` | `TachyonDispatcher` (cdef class) |
+| `_server_fast.pyx` | `_server_fast.cpython-*.so` | Direct `transport.write()` for HTTP/1.1 |
+
+Everything else is pure Python (no `.pyx` counterpart).
+
+---
+
+## Step-by-step
+
+### 1. Install Cython
+
+```bash
+pip install tachyon-api[fast]
+```
+
+This adds `cython>=3.0` to your environment.  The extras label is purely a
+convenience for declaring the optional dependency — `pip install` does NOT
+trigger compilation by itself.
+
+### 2. Compile in place
+
+```bash
+python setup.py build_ext --inplace
+```
+
+This invokes `cythonize()` on every `.pyx` listed in `setup.py`, compiles
+the generated `.c` into a platform-specific `.so`, and copies the `.so` next
+to the `.py` source.
+
+Output looks like:
+
+```
+copying build/.../tachyon_api/routing/trie.cpython-310-darwin.so       -> tachyon_api/routing
+copying build/.../tachyon_api/processing/compiler.cpython-310-darwin.so -> tachyon_api/processing
+copying build/.../tachyon_api/processing/parameters.cpython-310-darwin.so -> tachyon_api/processing
+...
+```
+
+### 3. Verify
+
+```python
+>>> from tachyon_api.processing import parameters
+>>> parameters.__file__
+'.../tachyon_api/processing/parameters.cpython-310-darwin.so'
+```
+
+If you see `.py` instead of `.so`, the compiled version wasn't built or
+isn't on the import path.
+
+---
+
+## Compiler flags
+
+`setup.py` ships with these defaults:
+
+```python
+extra_compile_args = ["-O2"]
+if sys.platform != "win32":
+    extra_compile_args += ["-ffast-math"]
+
+cythonize(
+    extensions,
+    compiler_directives={
+        "language_level": "3",
+        "boundscheck": False,
+        "wraparound": False,
+        "nonecheck": False,
+        "cdivision": True,
+        "embedsignature": False,
+    },
+)
+```
+
+The flags trade safety for speed — `boundscheck=False` disables bounds
+checking on indexed access, `cdivision=True` uses C division semantics, etc.
+These are safe in Tachyon's own hot path (verified by the test suite) but
+relaxing them isn't recommended for user-written `.pyx` modules without
+careful review.
+
+---
+
+## Falling back to pure Python
+
+Just delete (or don't compile) the `.so` files.  Python's import system
+re-resolves to the `.py` sibling:
+
+```bash
+find tachyon_api -name "*.cpython-*.so" -delete
+python -c "from tachyon_api.processing import parameters; print(parameters.__file__)"
+# .../tachyon_api/processing/parameters.py
+```
+
+You can run the entire test suite in both modes — it should pass identically
+in both cases:
+
+```bash
+# Compiled
+python setup.py build_ext --inplace
+pytest tests/ -q
+
+# Pure Python
+find tachyon_api -name "*.cpython-*.so" -delete
+pytest tests/ -q
+```
+
+The Tachyon CI runs both flavors to guard against drift between the `.py` and
+`.pyx` implementations.
+
+---
+
+## Troubleshooting
+
+### `error: command 'clang' failed with exit status 1` (macOS)
+
+Install Xcode Command Line Tools:
+
+```bash
+xcode-select --install
+```
+
+### Compiled `.so` not picked up
+
+- Run `python -c "import sys; print(sys.path)"` and confirm the `.so` is on
+  an importable path.
+- Make sure the `.so` matches your Python version: the filename includes
+  `cpython-310` (or `311`, `312`, …); compiling against the wrong Python
+  produces a `.so` Python silently ignores.
+
+### Rebuilding after editing a `.pyx`
+
+```bash
+python setup.py build_ext --inplace --force
+```
+
+`--force` re-cythonizes even if the source timestamp hasn't changed.
+
+---
+
+## Roadmap: v1.2.9 Cython sprint
+
+The v1.2.x SRP refactor (PRs #35 – #41) decomposed the framework into 63
+single-responsibility modules with `__slots__` and full type hints — every
+hot-path class is now a direct `cdef class` candidate.
+
+The v1.2.84 audit (next sub-version) will produce a prioritized list of
+modules to compile in v1.2.9, ordered by impact (µs saved per request).
+Current projection: ~0.85 µs FULL HANDLER target, ~7x over FastAPI
+(vs ~1.05 µs / ~5.5x today).

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@
 - [13. Request Lifecycle](./13-request-lifecycle.md) - Ciclo de vida de una request
 - [14. Migration from FastAPI](./14-migration-fastapi.md) - Guía de migración
 - [15. Best Practices](./15-best-practices.md) - Buenas prácticas
+- [16. Cython Build](./16-cython-build.md) - Compilar el hot path `[fast]`
 
 ---
 
@@ -36,11 +37,13 @@
 | Feature | Tachyon | FastAPI |
 |---------|---------|---------|
 | **Serialization** | msgspec + orjson | pydantic |
-| **Performance** | ⚡ Ultra-fast | Fast |
-| **Bundle Size** | Minimal | Larger |
-| **Learning Curve** | Easy (FastAPI-like) | Easy |
-| **Type Safety** | Full | Full |
-| **OpenAPI** | Automatic | Automatic |
+| **Performance** | ⚡ ~5.5x throughput on the published benchmarks | Fast |
+| **Routing** | Radix trie O(k), Cython-compiled | Regex scan O(N) |
+| **Bundle Size** | 4 core deps | ~15 deps |
+| **DI scopes** | 3 (singleton / request / transient) | 1 |
+| **Learning Curve** | Easy (FastAPI-like decorators) | Easy |
+| **Type Safety** | Full (msgspec Struct) | Full (Pydantic) |
+| **OpenAPI** | Automatic (incl. `List[Struct]`, multipart) | Automatic |
 
 ## 📦 Installation
 
@@ -78,7 +81,7 @@ Visit: http://localhost:8000/docs
 
 ## 📖 Version
 
-Current: **0.7.0**
+Current: **1.2.x** — see [CHANGELOG](../CHANGELOG.md) for full history.
 
 ## 📄 License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.813"
+version = "1.2.82"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary — v1.2.82 (2/4 of v1.2.8x audit/prep phase)

Brings the public documentation in line with everything that landed during v1.2.x.  No framework code changes.

## README.md
- Version badge \`1.1.0\` → \`1.2.x\`; tests badge \`233\` → \`366 passed\`
- Feature matrix expanded: DI scopes, WebSocket DI + typed paths, \`Body(List[Struct])\`, \`SecurityHeadersMiddleware\`, async \`create_client\`, new Architecture row
- **New Architecture section** with ASCII flow diagram of the request hot path
- DI snippet shows all three scopes
- WebSocket snippet uses typed \`uuid.UUID\` path + \`Depends(@injectable)\`
- Testing snippet shows \`create_client\` async pattern
- KYC demo summary refreshed (17 tests, async tests, exception handler)
- Docs table: +\`16-cython-build.md\` link

## docs/

| File | Update |
|---|---|
| \`README.md\` | version 0.7.0 → 1.2.x; "Why Tachyon?" expanded |
| \`02-architecture.md\` | New "Tachyon's Internal Architecture" section enumerating the 63 SRP modules (hot vs cold path) |
| \`03-dependency-injection.md\` | New Scopes section (singleton/request/transient) with decision matrix; async \`Depends\` notes; v1.2.811 subclass-handler fix coverage; summary table |
| \`10-websockets.md\` | New "Typed Path Params" + "DI in WebSocket handlers" sections |
| \`11-testing.md\` | \`create_client()\` documented as canonical async helper with full httpx kwargs |
| \`14-migration-fastapi.md\` | New "v1.2.x Gotchas" section (CORS opt-in, body-size default 2 MB, SecurityHeaders, sanitized UploadFile, subclass exception handlers); \`@injectable\` scopes; async test uses \`create_client\` |
| **\`16-cython-build.md\` (new)** | When + how to compile \`[fast]\`; extension list; fallback; perf delta; troubleshooting; v1.2.9 roadmap reference |

## Verification
- ✅ 366/367 framework tests still pass (no code touched)
- ✅ 16/17 example tests still pass