### PR TITLE
fix(v1.2.85): parameters.pyx security divergence — 2 v1.2.0 audit fixes never applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.85] — 2026-05-22
+
+**Fix the `parameters.pyx` ↔ `parameters.py` security divergence.**
+Two v1.2.0 audit fixes were applied to `parameters.py` but never propagated
+to `parameters.pyx` — production users running compiled Cython
+(`pip install tachyon-api[fast]`) silently retained the pre-v1.2.0 unsafe
+behavior.  Discovered while preparing the v1.2.9 sprint plan (v1.2.84) and
+fixed before starting Phase 1.
+
+### Security fixes (compiled-Cython users only)
+
+- **`_DEFAULT_MAX_BODY_SIZE`** in `parameters.pyx`: `10 * 1024 * 1024` → `2 * 1024 * 1024`
+  (10 MB → 2 MB).  Matches `parameters.py` set in v1.2.0 audit (PR #28).
+  Compiled-mode users had 5× the body-size limit of pure-Python-mode users.
+- **Null-byte rejection** in `_process_path` of `parameters.pyx`: added
+  `if "\x00" in value_str: return None, validation_error_response(...)`
+  before any type conversion.  Matches `parameters.py` set in v1.2.0
+  security audit (PR #27 — path-traversal hardening).  Compiled-mode users
+  could submit `\x00` in path params and reach the application handler.
+
+Cython recompiled (`python setup.py build_ext --inplace`).
+
+### Why v1.2.83 audit missed this
+
+The audit measured each implementation in isolation; it did not diff `.py`
+vs `.pyx` line-by-line.  The diff would have surfaced both at once.
+**Action for v1.2.9 Phase 7**: the no-`.so` CI matrix step gains a
+complementary check — run the security-audit tests in both modes; if
+behavior diverges, fail the matrix.
+
+### Verification
+
+- 366/367 framework tests pass (with `.so` loaded).
+- Compiled-mode smoke:
+  - `GET /p/foo%00bar` → 422 `{"code": "VALIDATION_ERROR", "error": "Invalid path parameter: x"}` (was: routed to handler with embedded null byte).
+  - `Tachyon(max_body_size=...)` still accepted; default lowered as expected.
+- FULL HANDLER cycle 1.04 – 1.06 µs across 3 runs — within v1.2.84 noise
+  (the extra `"\x00" in str` check is sub-nanosecond).
+
+---
+
 ## [1.2.84] — 2026-05-22
 
 **v1.2.8x project audit / Cython prep — sub-version 4/4: Cython impact analysis.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.84"
+version = "1.2.85"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/tachyon_api/processing/parameters.pyx
+++ b/tachyon_api/processing/parameters.pyx
@@ -86,7 +86,7 @@ cdef int _KIND_PATH_IMPLICIT = KIND_PATH_IMPLICIT
 cdef int _KIND_DEP_CALLABLE  = KIND_DEP_CALLABLE
 cdef int _KIND_DEP_CLASS     = KIND_DEP_CLASS
 
-cdef int _DEFAULT_MAX_BODY_SIZE = 10 * 1024 * 1024
+cdef int _DEFAULT_MAX_BODY_SIZE = 2 * 1024 * 1024  # 2 MB — matches parameters.py (v1.2.0 audit)
 
 
 cdef class ParameterProcessor:
@@ -326,6 +326,9 @@ cdef class ParameterProcessor:
             return None, None
 
         value_str = path_params[name]
+        # v1.2.0 audit: reject null bytes in path params (path-traversal hardening)
+        if "\x00" in value_str:
+            return None, validation_error_response(f"Invalid path parameter: {name}")
 
         if is_list:
             parts = value_str.split(",") if value_str else []


### PR DESCRIPTION
## Summary

While preparing the v1.2.9 sprint plan (v1.2.84), a direct line-by-line diff of \`parameters.py\` vs \`parameters.pyx\` surfaced **two v1.2.0 security fixes that were applied to the .py but never to the .pyx**.  Compiled-Cython users (\`pip install tachyon-api[fast]\`) silently retained the pre-v1.2.0 unsafe behavior since the v1.2.0 release.

The v1.2.83 audit missed this because it measured each implementation in isolation.

## The two divergences

| # | Setting | parameters.py (v1.2.0+) | parameters.pyx (until this PR) | Impact in compiled mode |
|---|---|---|---|---|
| 1 | \`_DEFAULT_MAX_BODY_SIZE\` | 2 MB | **10 MB** | 5× the body-size limit; DoS surface wider than documented |
| 2 | Null-byte check in \`_process_path\` | Yes — returns 422 | **Missing** | \`\x00\` reached the handler in path params; path-traversal hardening (PR #27) bypassed |

## Fix

- \`parameters.pyx\` line 89: \`cdef int _DEFAULT_MAX_BODY_SIZE = 2 * 1024 * 1024\`
- \`parameters.pyx\` \`_process_path\`: added \`if "\x00" in value_str: return None, validation_error_response(f"Invalid path parameter: {name}")\` before any type conversion.
- Recompiled (\`python setup.py build_ext --inplace\`).

## Verification

- 366/367 framework tests pass (compiled mode)
- Smoke (compiled mode): \`GET /p/foo%00bar\` → 422 \`{"code": "VALIDATION_ERROR"}\` (was: handler called with embedded null byte)
- FULL HANDLER 1.04–1.06 µs across 3 runs — within v1.2.84 noise

## Follow-up

v1.2.9 Phase 7 will add a \`.py\` vs \`.pyx\` security-audit consistency check to the no-\`.so\` CI matrix step so this never recurs.