### PR TITLE
perf(v1.2.92): Phase 2/7 — DI resolver pipeline compiled (cdef class)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.92] — 2026-05-22
+
+**v1.2.9 Cython sprint — Phase 2/7: DI resolver pipeline compiled (cdef class).**
+Result: **resolve_dependency 41–50% faster** across all three scopes; FULL
+HANDLER unchanged in non-DI scenarios (as expected — the resolver isn't on
+the path for endpoints without `@injectable` or `Depends`).
+
+### Added (5 new compiled modules)
+
+- **`processing/dependencies/_override_lookup.pyx`** — `cdef class OverrideLookup`
+- **`processing/dependencies/_scope_cache.pyx`** — `cdef class ScopeCache`
+- **`processing/dependencies/_circular_detector.pyx`** — `cdef class CircularDetector`
+- **`processing/dependencies/_class_factory.pyx`** — `cdef class ClassFactory`
+- **`processing/dependencies/_resolver.pyx`** — `cdef class DependencyResolver`
+  (orchestrator; preserves the `_resolving` legacy attribute for backward compat)
+
+Unlike Phase 1, these classes have no Python parent class, so `cdef class`
+is viable and the typed attribute slots (`cdef object _app`, etc.) actually
+take effect.
+
+`_callable_factory.py` and `_sig_cache.py` deliberately stay in pure Python
+per the v1.2.84 plan: callable factory mixes async + recursion + nested
+resolve and is the riskiest cdef target; sig cache is a dict lookup
+already at C level.
+
+### Changed
+
+- **`setup.py`** — five new `Extension` entries.  Cython now produces 15
+  compiled `.so` files (was 10 after Phase 1).
+
+### Added (benchmark)
+
+- **`benchmark/profile_di.py`** — DI-specific micro-bench measuring
+  `resolve_dependency` for each scope.  Was missing from the bench suite;
+  needed to validate Phase 2.
+
+### Measurements
+
+**`benchmark/profile_di.py`, compiled vs pure-Python fallback:**
+
+| Scope | Pure Python `.py` | Compiled `.pyx` | Δ |
+|---|---:|---:|---:|
+| singleton (cache hit) | 0.343 µs/iter | **0.172 µs/iter** | **−50%** |
+| request (fresh cache) | 0.970 µs/iter | **0.557 µs/iter** | **−43%** |
+| transient (always new) | 0.889 µs/iter | **0.522 µs/iter** | **−41%** |
+
+Per request, assuming 1–2 deps resolved, that's roughly **−0.20 to −0.40 µs
+on endpoints with DI**.
+
+**`benchmark/profile_hotpath.py` (no-DI scenarios, 10-run median):**
+
+| Metric | v1.2.91 baseline | v1.2.92 | Δ |
+|---|---:|---:|---:|
+| FULL HANDLER cycle | 0.93 µs | 0.93–0.94 µs | within noise |
+
+Phase 2 gate ("no regression in non-DI") **PASSED**.
+
+### Verification
+
+- 366/367 framework tests pass with compiled `.so` loaded.
+- The `DependencyResolver._resolving` legacy attribute (used by at least one
+  test) is preserved as a `cdef public set` mirroring `_circular._resolving`.
+- The orchestrator's `__init__` ordering is unchanged: collaborators are
+  constructed in the same sequence, `OverrideLookup` reads
+  `app.dependency_overrides` lazily at lookup time (preserves the
+  pre-construction tolerance from v1.2.4).
+
+### v1.2.9 status
+
+After Phase 2: FULL HANDLER stable at ~0.93 µs (no-DI); DI scenarios get
+visible per-request speedups proportional to how many deps the endpoint uses.
+
+Phases remaining: 3 (ExceptionTable), 4a/b/c (extractors), 5 (nogil bearer),
+6 (fix 2 known-failing tests), 7 (no-`.so` CI matrix).
+
+---
+
 ## [1.2.91] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 1/7: response classes compiled.**

--- a/benchmark/profile_di.py
+++ b/benchmark/profile_di.py
@@ -1,0 +1,76 @@
+"""Micro-bench for the DI resolver hot path.
+
+Compares DependencyResolver.resolve_dependency across N iterations for
+the three scopes (singleton, request, transient).  Used by Phase 2 of the
+v1.2.9 Cython sprint to confirm the cdef-class migration actually helps
+DI-heavy endpoints.
+"""
+
+import asyncio
+import time
+
+from tachyon_api import Tachyon, injectable
+from tachyon_api.processing.dependencies import DependencyResolver
+
+N = 200_000
+
+
+@injectable
+class SingletonDep:
+    def __init__(self):
+        self.value = 42
+
+
+@injectable(scope="request")
+class RequestDep:
+    def __init__(self):
+        self.value = "request-scoped"
+
+
+@injectable(scope="transient")
+class TransientDep:
+    def __init__(self):
+        self._seq = 0
+
+
+def _bench(label: str, fn, n: int) -> None:
+    t0 = time.perf_counter()
+    fn(n)
+    elapsed = time.perf_counter() - t0
+    per_iter_us = elapsed / n * 1_000_000
+    qps = n / elapsed
+    print(f"  {label:50s} {per_iter_us:6.3f} µs/iter   {qps:>10,.0f} iter/s")
+
+
+async def main():
+    app = Tachyon()
+    resolver = DependencyResolver(app)
+
+    # Pre-warm: first resolve populates the cache
+    resolver.resolve_dependency(SingletonDep)
+
+    print("═" * 80)
+    print("  DI RESOLVER MICRO-BENCH (cdef classes — Phase 2 of v1.2.9)")
+    print("═" * 80)
+
+    def run_singleton(n):
+        for _ in range(n):
+            resolver.resolve_dependency(SingletonDep)
+
+    def run_request(n):
+        for _ in range(n):
+            cache = {}
+            resolver.resolve_dependency(RequestDep, cache)
+
+    def run_transient(n):
+        for _ in range(n):
+            resolver.resolve_dependency(TransientDep)
+
+    _bench("resolve_dependency — singleton (cache hit)", run_singleton, N)
+    _bench("resolve_dependency — request (fresh cache)", run_request, N)
+    _bench("resolve_dependency — transient (always new)", run_transient, N)
+
+    print("═" * 80 + "\n")
+
+
+asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.91"
+version = "1.2.92"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ try:
             sources=["tachyon_api/_server_fast.pyx"],
             extra_compile_args=extra_compile_args,
         ),
-        # v1.2.91 — Phase 1: response classes as cdef class
+        # v1.2.91 — Phase 1: response classes as compiled .pyx (regular class,
+        # cdef class blocked by Starlette JSONResponse parent — see CHANGELOG).
         Extension(
             "tachyon_api.responses._json_response",
             sources=["tachyon_api/responses/_json_response.pyx"],
@@ -71,6 +72,33 @@ try:
         Extension(
             "tachyon_api.responses._internal_error",
             sources=["tachyon_api/responses/_internal_error.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        # v1.2.92 — Phase 2: DI resolver pipeline as cdef class (no Python
+        # parent, so cdef class is viable here unlike Phase 1).
+        Extension(
+            "tachyon_api.processing.dependencies._override_lookup",
+            sources=["tachyon_api/processing/dependencies/_override_lookup.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing.dependencies._scope_cache",
+            sources=["tachyon_api/processing/dependencies/_scope_cache.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing.dependencies._circular_detector",
+            sources=["tachyon_api/processing/dependencies/_circular_detector.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing.dependencies._class_factory",
+            sources=["tachyon_api/processing/dependencies/_class_factory.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing.dependencies._resolver",
+            sources=["tachyon_api/processing/dependencies/_resolver.pyx"],
             extra_compile_args=extra_compile_args,
         ),
     ]

--- a/tachyon_api/processing/dependencies/_circular_detector.pyx
+++ b/tachyon_api/processing/dependencies/_circular_detector.pyx
@@ -1,0 +1,25 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled circular-dependency detector.
+
+Sibling of `_circular_detector.py`. cdef class so `_resolving` is a C-level
+slot (set ops are unchanged but attribute access is faster).
+"""
+
+
+cdef class CircularDetector:
+    """Tracks classes currently being resolved; raises on cycle."""
+
+    cdef public set _resolving
+
+    def __init__(self):
+        self._resolving = set()
+
+    def check_and_enter(self, cls):
+        if cls in self._resolving:
+            raise TypeError(
+                f"Circular dependency detected while resolving '{cls.__name__}'"
+            )
+        self._resolving.add(cls)
+
+    def exit(self, cls):
+        self._resolving.discard(cls)

--- a/tachyon_api/processing/dependencies/_class_factory.pyx
+++ b/tachyon_api/processing/dependencies/_class_factory.pyx
@@ -1,0 +1,35 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled class-dep instantiator.
+
+Sibling of `_class_factory.py`.  Builds an `@injectable` class instance by
+resolving its constructor dependencies recursively through the supplied
+resolver callback.
+"""
+
+import inspect
+
+from ._sig_cache import get_signature
+
+
+cdef class ClassFactory:
+    """Builds a class instance by resolving every typed constructor parameter."""
+
+    cdef object _resolve_dep
+
+    def __init__(self, resolve_dep):
+        # resolve_dep is the recursive resolver (DependencyResolver.resolve_dependency)
+        self._resolve_dep = resolve_dep
+
+    def build(self, cls, request_cache):
+        sig = get_signature(cls)
+        cdef dict nested = {}
+        for param in sig.parameters.values():
+            if param.name == "self":
+                continue
+            if param.annotation is inspect.Parameter.empty:
+                raise TypeError(
+                    f"Parameter '{param.name}' in '{cls.__name__}' has no type annotation; "
+                    f"cannot resolve dependency."
+                )
+            nested[param.name] = self._resolve_dep(param.annotation, request_cache)
+        return cls(**nested)

--- a/tachyon_api/processing/dependencies/_override_lookup.pyx
+++ b/tachyon_api/processing/dependencies/_override_lookup.pyx
@@ -1,0 +1,31 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled dependency-override lookup.
+
+Sibling of `_override_lookup.py`. cdef class so attribute access (`self._app`)
+goes through a C-level slot instead of a dict lookup.
+
+Returns the resolved override value (invoking the override factory if callable)
+or the module-level `_SENTINEL` if no override is registered.  Callers must
+compare against `_SENTINEL` instead of `None` because `None` is a valid
+override value.
+"""
+
+_SENTINEL = object()
+
+
+cdef class OverrideLookup:
+    """Answers: "is there a registered override for this dependency key?" """
+
+    cdef object _app
+
+    def __init__(self, app):
+        self._app = app
+
+    def lookup(self, key):
+        overrides = self._app.dependency_overrides
+        if key not in overrides:
+            return _SENTINEL
+        override = overrides[key]
+        if callable(override):
+            return override()
+        return override

--- a/tachyon_api/processing/dependencies/_resolver.pyx
+++ b/tachyon_api/processing/dependencies/_resolver.pyx
@@ -1,0 +1,89 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled dependency-resolution orchestrator.
+
+Sibling of `_resolver.py`. cdef class wiring the 6 collaborators (override
+lookup, scope cache, sig cache, circular detector, class factory, callable
+factory) into the resolve_dependency / resolve_callable_dependency pipeline.
+
+Public surface (unchanged from v1.2.0):
+  - resolve_dependency(cls, request_cache=None) -> instance
+  - resolve_callable_dependency(dependency, cache, request) -> awaited result
+"""
+
+import asyncio
+
+from ...di import _registry
+from ._callable_factory import CallableFactory
+from ._circular_detector import CircularDetector
+from ._class_factory import ClassFactory
+from ._override_lookup import _SENTINEL, OverrideLookup
+from ._scope_cache import ScopeCache
+
+
+cdef class DependencyResolver:
+    """Orchestrates class-based and callable-based dependency resolution."""
+
+    cdef public object app
+    cdef object _overrides
+    cdef object _scope_cache
+    cdef object _circular
+    cdef object _class_factory
+    cdef object _callable_factory
+    # legacy attribute — was a set used by the old monolithic resolver; some
+    # external code (and at least one test) introspected it
+    cdef public set _resolving
+
+    def __init__(self, app_instance):
+        self.app = app_instance
+        self._overrides = OverrideLookup(app_instance)
+        self._scope_cache = ScopeCache(app_instance)
+        self._circular = CircularDetector()
+        self._class_factory = ClassFactory(self.resolve_dependency)
+        self._callable_factory = CallableFactory(
+            self.resolve_dependency, self.resolve_callable_dependency
+        )
+        self._resolving = self._circular._resolving
+
+    def resolve_dependency(self, cls, request_cache=None):
+        override = self._overrides.lookup(cls)
+        if override is not _SENTINEL:
+            return override
+
+        cdef str scope = self._scope_cache.get_scope(cls)
+        cached = self._scope_cache.lookup(cls, scope, request_cache)
+        if cached is not None:
+            return cached
+
+        if cls not in _registry:
+            try:
+                return cls()
+            except TypeError:
+                raise TypeError(
+                    f"Cannot resolve dependency '{cls.__name__}'. "
+                    f"Did you forget to mark it with @injectable?"
+                )
+
+        self._circular.check_and_enter(cls)
+        try:
+            instance = self._class_factory.build(cls, request_cache)
+        finally:
+            self._circular.exit(cls)
+
+        self._scope_cache.store(cls, instance, scope, request_cache)
+        return instance
+
+    async def resolve_callable_dependency(self, dependency, cache, request):
+        override = self._overrides.lookup(dependency)
+        if override is not _SENTINEL:
+            if asyncio.iscoroutine(override):
+                return await override
+            return override
+
+        if cache is not None and dependency in cache:
+            return cache[dependency]
+
+        result = await self._callable_factory.invoke(dependency, cache, request)
+
+        if cache is not None:
+            cache[dependency] = result
+        return result

--- a/tachyon_api/processing/dependencies/_scope_cache.pyx
+++ b/tachyon_api/processing/dependencies/_scope_cache.pyx
@@ -1,0 +1,36 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled scope-aware class-dep cache.
+
+Sibling of `_scope_cache.py`.  cdef class.  Indexes the per-class instances
+according to the declared scope (singleton / request / transient).
+"""
+
+from ...di import SCOPE_REQUEST, SCOPE_SINGLETON, _scopes
+
+
+cdef class ScopeCache:
+    """Looks up and stores class instances according to their declared scope."""
+
+    cdef object _app
+
+    def __init__(self, app):
+        self._app = app
+
+    @staticmethod
+    def get_scope(cls):
+        return _scopes.get(cls, SCOPE_SINGLETON)
+
+    def lookup(self, cls, scope, request_cache):
+        if scope == SCOPE_SINGLETON:
+            return self._app.get_instance(cls)
+        if scope == SCOPE_REQUEST and request_cache is not None:
+            return request_cache.get(cls)
+        # SCOPE_TRANSIENT — never cached
+        return None
+
+    def store(self, cls, instance, scope, request_cache):
+        if scope == SCOPE_SINGLETON:
+            self._app.register_instance(cls, instance)
+        elif scope == SCOPE_REQUEST and request_cache is not None:
+            request_cache[cls] = instance
+        # SCOPE_TRANSIENT — no-op


### PR DESCRIPTION
## Summary — v1.2.9 Phase 2/7

Five cdef class modules compiled.  Unlike Phase 1, these classes have no Python parent class so \`cdef class\` is viable — typed attribute slots actually take effect.

## Added (5 new compiled modules)

| File | Class |
|---|---|
| \`processing/dependencies/_override_lookup.pyx\` | \`cdef class OverrideLookup\` |
| \`processing/dependencies/_scope_cache.pyx\` | \`cdef class ScopeCache\` |
| \`processing/dependencies/_circular_detector.pyx\` | \`cdef class CircularDetector\` |
| \`processing/dependencies/_class_factory.pyx\` | \`cdef class ClassFactory\` |
| \`processing/dependencies/_resolver.pyx\` | \`cdef class DependencyResolver\` |

\`setup.py\` grows from 10 → 15 compiled extensions.

\`_callable_factory.py\` and \`_sig_cache.py\` deliberately stay in pure Python per the v1.2.84 plan.

## Added benchmark

**\`benchmark/profile_di.py\`** — was missing.  Needed to validate Phase 2 since \`profile_hotpath.py\` has no DI scenario.

## Measurements

### \`benchmark/profile_di.py\` — compiled vs pure Python fallback

| Scope | Pure Python \`.py\` | Compiled \`.pyx\` | Δ |
|---|---:|---:|---:|
| singleton (cache hit) | 0.343 µs/iter | **0.172 µs/iter** | **−50%** |
| request (fresh cache) | 0.970 µs/iter | **0.557 µs/iter** | **−43%** |
| transient (always new) | 0.889 µs/iter | **0.522 µs/iter** | **−41%** |

Per endpoint with 1–2 deps that's roughly **−0.20 to −0.40 µs** of savings.

### \`benchmark/profile_hotpath.py\` (non-DI scenarios, 10-run median)

| Metric | v1.2.91 baseline | v1.2.92 | Δ |
|---|---:|---:|---:|
| FULL HANDLER cycle | 0.93 µs | 0.93–0.94 µs | within noise |

**Phase 2 gate ("no regression in non-DI"): PASSED.**

> Initial 5-run sample saw a 0.96-1.00 spread that looked like a regression; 10 runs sorted showed the true median sits at 0.93–0.94.  Lesson: 5-run medians are too few when variance is high.

## Verification

- ✅ 366/367 framework tests pass with compiled \`.so\` loaded
- ✅ \`DependencyResolver._resolving\` legacy attribute preserved as \`cdef public set\`
- ✅ \`OverrideLookup\` still reads \`app.dependency_overrides\` lazily at lookup time (preserves the pre-construction tolerance from v1.2.4)