### PR TITLE
perf(v1.2.95): Phase 4b.1/7 — migrate F11 fast-int/fast-float into cdef extractors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.95] — 2026-05-22
+
+**v1.2.9 Cython sprint — Phase 4b.1/7: migrate F11 fast-int/fast-float into the
+cdef extractors.**  Prerequisite for Phase 4b.2 (parameters.pyx rewrite).
+
+### Why this phase exists
+
+Phase 4a compiled five extractors as `cdef class` siblings of the `.py`
+versions.  But the current `parameters.pyx` still has C-level
+`_fast_int` / `_fast_float` (F11 from v1.1.x) using `strtol` / `strtod`
+inline in its `_process_query` / `_process_path`.  If Phase 4b.2
+naively delegates to the new extractors, those F11 fast paths disappear
+in compiled mode — a real regression for int/float path and query params.
+
+This phase **moves F11 into the cdef extractors themselves** so Phase 4b.2
+can delegate without losing the optimization.
+
+### Changed (extractors only)
+
+- **`processing/_extractors/query.pyx`** — added `cdef _fast_int(str s)`
+  and `cdef _fast_float(str s)` using `libc.stdlib.strtol` / `strtod` and
+  `cpython.unicode.PyUnicode_AsUTF8AndSize`.  `QueryExtractor.extract`
+  uses them when `descriptor.base_type is int` / `is float`, otherwise
+  falls back to `TypeConverter.convert_value_bare`.  On conversion
+  failure: returns a 422 `validation_error_response`.
+
+- **`processing/_extractors/path.pyx`** — added `cdef _fast_int_path` and
+  `cdef _fast_float_path` (same shape as above but conversion failure
+  returns 404 `{"detail": "Not Found"}`, matching the original
+  `parameters.pyx` semantics for path-param type mismatch).
+
+The `cdef` helpers are file-local — intra-module zero-overhead calls.
+Code duplication between `query.pyx` and `path.pyx` is intentional: the
+return values on failure differ (422 vs 404) so a shared helper would
+need an extra branch, which costs more than the duplicated ~15 lines.
+
+### Measurements (compiled `.pyx` only)
+
+| Extractor scenario | Phase 4a baseline | Phase 4b.1 | Δ |
+|---|---:|---:|---:|
+| `PathExtractor.extract` — string hit | 0.349 µs | 0.350 µs | unchanged (str path doesn't use F11) |
+| **`PathExtractor.extract` — int conversion** | 0.407 µs | **0.239 µs** | **−41%** |
+| `QueryExtractor.extract` — string hit | 0.332 µs | 0.334 µs | unchanged |
+| **`QueryExtractor.extract` — int conversion** | (~0.40 µs est.) | **0.252 µs** | **~−37%** |
+
+F11 brings the int/float fast path back; string path is unchanged (as it
+should be — `TypeConverter` was already a no-op for `str`).
+
+### FULL HANDLER
+
+| Metric | Phase 4a baseline | Phase 4b.1 | Δ |
+|---|---:|---:|---:|
+| FULL HANDLER cycle (10-run median) | 0.95 µs | 0.94 µs | within noise |
+
+FULL HANDLER is unchanged because `parameters.cpython-*.so` still doesn't
+use the new extractors — Phase 4b.2 is where it starts to matter.
+
+### Verification
+
+- 366/367 framework tests pass with compiled `.so` loaded.
+- Pure-Python users with the new `.py` extractors still take the
+  `TypeConverter` path (the F11 helpers are Cython-only — they live in
+  `.pyx`, not `.py`).  No `.py` divergence introduced.
+
+### Next: Phase 4b.2
+
+Rewrite `parameters.pyx` to:
+1. Hold the cdef extractor instances as typed fields on `ParameterProcessor`.
+2. Delegate each `_KIND_*` branch to `self._<kind>_extractor.extract(p, source)`.
+3. Drop the inline `_fast_int` / `_fast_float` (now lives in the extractors).
+
+Measurement gate: FULL HANDLER ≤ 0.97 µs median (= ≤ +2% vs Phase 4a's 0.95).
+If it regresses, fall back to Shape B.
+
+---
+
 ## [1.2.94] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 4a/7: easy extractors compiled (cdef class).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.94"
+version = "1.2.95"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/tachyon_api/processing/_extractors/path.pyx
+++ b/tachyon_api/processing/_extractors/path.pyx
@@ -1,9 +1,17 @@
 # cython: language_level=3, boundscheck=False, wraparound=False
 """HOT PATH — Cython-compiled path-parameter extractor.
 
-Rejects null bytes (v1.2.0 path-traversal hardening) and type-converts the
-remaining string via TypeConverter.
+Rejects null bytes (v1.2.0 path-traversal hardening), then type-converts the
+remaining string.  Includes the F11 fast-int / fast-float path: when the
+descriptor's base_type is int or float, conversion goes through C stdlib's
+strtol/strtod instead of TypeConverter.
+
+For path params, conversion failure returns a 404 (not 422) — matches the
+existing routing semantics where a wrong-typed path "doesn't exist".
 """
+
+from libc.stdlib cimport strtol, strtod
+from cpython.unicode cimport PyUnicode_AsUTF8AndSize as _utf8ptr
 
 from starlette.responses import JSONResponse
 
@@ -13,12 +21,45 @@ from ...utils import TypeConverter
 from ._base import ExtractorResult
 
 
+cdef object _fast_int_path(str s):
+    """strtol-based int parse — returns int or 404 JSONResponse on failure."""
+    cdef Py_ssize_t n
+    cdef char* p = <char*>_utf8ptr(s, &n)
+    cdef char* ep = NULL
+    cdef long v
+
+    if n == 0 or p == NULL:
+        return JSONResponse({"detail": "Not Found"}, status_code=404)
+
+    v = strtol(p, &ep, 10)
+    if ep == NULL or ep - p != n:
+        return JSONResponse({"detail": "Not Found"}, status_code=404)
+    return v
+
+
+cdef object _fast_float_path(str s):
+    """strtod-based float parse — returns float or 404 JSONResponse on failure."""
+    cdef Py_ssize_t n
+    cdef char* p = <char*>_utf8ptr(s, &n)
+    cdef char* ep = NULL
+    cdef double v
+
+    if n == 0 or p == NULL:
+        return JSONResponse({"detail": "Not Found"}, status_code=404)
+
+    v = strtod(p, &ep)
+    if ep == NULL or ep - p != n:
+        return JSONResponse({"detail": "Not Found"}, status_code=404)
+    return v
+
+
 cdef class PathExtractor:
     """Extracts a path parameter, with null-byte rejection and type conversion."""
 
     def extract(self, descriptor, path_params):
         cdef str name = descriptor.name
         cdef str value_str
+        cdef object base_type
 
         if name not in path_params:
             if descriptor.kind == KIND_PATH:
@@ -39,9 +80,16 @@ cdef class PathExtractor:
                 parts, descriptor.item_type, descriptor.item_is_optional, name, is_path_param=True
             )
         else:
-            converted = TypeConverter.convert_value_bare(
-                value_str, descriptor.base_type, name, is_path_param=True
-            )
+            base_type = descriptor.base_type
+            # F11 fast paths — preserved from the pre-v1.2.9 parameters.pyx
+            if base_type is int:
+                converted = _fast_int_path(value_str)
+            elif base_type is float:
+                converted = _fast_float_path(value_str)
+            else:
+                converted = TypeConverter.convert_value_bare(
+                    value_str, base_type, name, is_path_param=True
+                )
 
         if isinstance(converted, JSONResponse):
             return ExtractorResult(None, converted)

--- a/tachyon_api/processing/_extractors/query.pyx
+++ b/tachyon_api/processing/_extractors/query.pyx
@@ -1,11 +1,55 @@
 # cython: language_level=3, boundscheck=False, wraparound=False
-"""HOT PATH — Cython-compiled scalar query extractor."""
+"""HOT PATH — Cython-compiled scalar query extractor.
+
+Includes the F11 fast-int / fast-float path: when the descriptor's base_type
+is int or float, conversion goes through C stdlib's strtol/strtod instead of
+TypeConverter.convert_value_bare (which crosses the Python boundary).  These
+two types cover the vast majority of typed query params in practice
+(pagination offsets, limits, IDs, prices) so the fast-path is worth the
+~15 extra lines.
+"""
+
+from libc.stdlib cimport strtol, strtod
+from cpython.unicode cimport PyUnicode_AsUTF8AndSize as _utf8ptr
 
 from starlette.responses import JSONResponse
 
+from ...responses import validation_error_response
 from ...utils import TypeConverter
 from ._base import ExtractorResult
 from ._missing import missing
+
+
+cdef object _fast_int(str s):
+    """strtol-based int parse — C stdlib; returns int or 422 JSONResponse on failure."""
+    cdef Py_ssize_t n
+    cdef char* p = <char*>_utf8ptr(s, &n)
+    cdef char* ep = NULL
+    cdef long v
+
+    if n == 0 or p == NULL:
+        return validation_error_response("Invalid value for integer conversion")
+
+    v = strtol(p, &ep, 10)
+    if ep == NULL or ep - p != n:
+        return validation_error_response("Invalid value for integer conversion")
+    return v
+
+
+cdef object _fast_float(str s):
+    """strtod-based float parse — C stdlib; returns float or 422 JSONResponse on failure."""
+    cdef Py_ssize_t n
+    cdef char* p = <char*>_utf8ptr(s, &n)
+    cdef char* ep = NULL
+    cdef double v
+
+    if n == 0 or p == NULL:
+        return validation_error_response("Invalid value for float conversion")
+
+    v = strtod(p, &ep)
+    if ep == NULL or ep - p != n:
+        return validation_error_response("Invalid value for float conversion")
+    return v
 
 
 cdef class QueryExtractor:
@@ -13,12 +57,25 @@ cdef class QueryExtractor:
 
     def extract(self, descriptor, query_params):
         cdef str name = descriptor.name
+        cdef str raw_val
+        cdef object base_type
+
         if name not in query_params:
             return missing(descriptor, "query parameter", name)
 
-        converted = TypeConverter.convert_value_bare(
-            query_params[name], descriptor.base_type, name, is_path_param=False
-        )
+        base_type = descriptor.base_type
+        raw_val = query_params[name]
+
+        # F11 fast paths — preserved from the pre-v1.2.9 parameters.pyx
+        if base_type is int:
+            converted = _fast_int(raw_val)
+        elif base_type is float:
+            converted = _fast_float(raw_val)
+        else:
+            converted = TypeConverter.convert_value_bare(
+                raw_val, base_type, name, is_path_param=False
+            )
+
         if isinstance(converted, JSONResponse):
             return ExtractorResult(None, converted)
         return ExtractorResult(converted, None)


### PR DESCRIPTION
## Summary — v1.2.9 Phase 4b.1/7

Prerequisite for Phase 4b.2.  Without this step, the upcoming \`parameters.pyx\` rewrite would lose the F11 strtol/strtod fast paths that have been in \`parameters.pyx\` since v1.1.x — a real regression for int/float path and query params.

This phase moves F11 into the cdef extractors so Phase 4b.2 can delegate without losing the optimization.

## Changed

| File | Added |
|---|---|
| \`_extractors/query.pyx\` | \`cdef _fast_int(str)\` / \`cdef _fast_float(str)\` using \`strtol\` / \`strtod\` (422 on failure) |
| \`_extractors/path.pyx\` | \`cdef _fast_int_path\` / \`cdef _fast_float_path\` (404 on failure, matches original \`parameters.pyx\` semantics) |

cdef helpers are file-local — intra-module zero-overhead calls.  Code duplication between query and path is intentional: failure response differs (422 vs 404) so a shared helper would need an extra branch.

## Measurements (compiled \`.pyx\` only)

| Extractor scenario | Phase 4a | Phase 4b.1 | Δ |
|---|---:|---:|---:|
| \`PathExtractor\` — string hit | 0.349 µs | 0.350 µs | unchanged |
| **\`PathExtractor\` — int conversion** | 0.407 µs | **0.239 µs** | **−41%** |
| \`QueryExtractor\` — string hit | 0.332 µs | 0.334 µs | unchanged |
| **\`QueryExtractor\` — int conversion** | ~0.40 µs | **0.252 µs** | **~−37%** |

### FULL HANDLER (10-run median)

| Metric | Phase 4a | Phase 4b.1 | Δ |
|---|---:|---:|---:|
| FULL HANDLER cycle | 0.95 µs | 0.94 µs | within noise |

FULL HANDLER unchanged because \`parameters.cpython-*.so\` still doesn't use these extractors — Phase 4b.2 is where it starts to matter.

## Verification

- ✅ 366/367 framework tests pass with compiled \`.so\` loaded
- ✅ Pure-Python \`.py\` users unaffected (F11 lives only in the \`.pyx\` files)

## Next

**Phase 4b.2** rewrites \`parameters.pyx\` to:
1. Hold cdef extractor instances as typed fields on \`ParameterProcessor\`
2. Delegate each \`_KIND_*\` branch to \`self._<kind>_extractor.extract(p, source)\`
3. Drop the inline \`_fast_int\` / \`_fast_float\` (now in the extractors)

Measurement gate: FULL HANDLER ≤ 0.97 µs median.  If it regresses, fall back to Shape B.