### PR TITLE
perf(v1.2.97): Phase 4b.3/7 — .pxd + cimport recover path+query regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.97] — 2026-05-22
+
+**v1.2.9 Cython sprint — Phase 4b.3/7: `.pxd` declarations + `cimport` recover
+the Phase 4b.2 path+query regression.**
+
+Phase 4b.2 introduced cross-module cdef dispatch overhead because
+`parameters.pyx` held extractor instances as `cdef object` (untyped) — each
+call went through Python's method machinery.  This phase adds `.pxd`
+declarations to each cdef extractor and uses `cimport` to get typed C-level
+references, enabling direct extension-type slot dispatch.
+
+### Added (4 new `.pxd` files)
+
+- `processing/_extractors/header.pxd` — `cdef class HeaderExtractor` + `cpdef extract`
+- `processing/_extractors/cookie.pxd` — same for `CookieExtractor`
+- `processing/_extractors/query.pxd` — same for `QueryExtractor`
+- `processing/_extractors/path.pxd` — same for `PathExtractor`
+
+### Changed
+
+- Each extractor's `.pyx`: `def extract(...)` → `cpdef extract(self, object descriptor, object source)`
+  (`cpdef` required to match the `.pxd` declaration).
+- `processing/parameters.pyx`:
+  - `cimport` each extractor class for the C-level type.
+  - Renamed Python imports to `_X_py` aliases for use as constructors.
+  - Extractor fields typed as the actual cdef class (`cdef HeaderExtractor _header_extractor`) instead of `cdef object`.
+  - Cython now generates direct slot dispatch for `self._header_extractor.extract(...)`.
+
+### Measurements (10-run median, compiled mode)
+
+| Metric | Phase 4b.2 | Phase 4b.3 | Δ vs 4b.2 | Δ vs v1.2.83 baseline |
+|---|---:|---:|---:|---:|
+| **FULL HANDLER cycle** | 0.965 µs | **0.95 µs** | −1.5% | **−9.5%** |
+| `process_parameters` — path+query | 0.635 µs | **0.595 µs** | **−6.3%** | +4.4% |
+| `process_parameters` — body POST | 0.80 µs | 0.80 µs | unchanged | unchanged |
+| `process_parameters` — no params | 0.16 µs | 0.16 µs | unchanged | unchanged |
+
+path+query regression dropped from +11.4% (4b.2) to +4.4% (4b.3) vs the
+v1.2.83 baseline.  Remaining gap is `descriptor.*` Python attribute access
+inside the extractors — not addressable without deeper changes.
+
+### Verification
+
+- 366/367 framework tests pass with `.so` loaded.
+- 366/367 framework tests pass without `.so` (pure-Python fallback) — both
+  modes agree.  `.pxd` is a Cython-only artifact, no impact on `.py`.
+- F11 fast-int/fast-float preserved.
+
+### Sprint status
+
+After Phase 4b.3 the v1.2.9 sprint hits **0.95 µs FULL HANDLER median**,
+matching the conservative target (`≤ 0.95 µs`) declared in `docs/cython-plan-v1.2.9.md`.
+
+Remaining: Phase 4c (body/form/file/query_list to cdef), Phase 5 (nogil
+bearer), Phase 6 (fix known-failing tests), Phase 7 (CI matrix).
+
+---
+
 ## [1.2.96] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 4b.2/7: `parameters.pyx` delegates to cdef

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.96"
+version = "1.2.97"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/tachyon_api/processing/_extractors/cookie.pxd
+++ b/tachyon_api/processing/_extractors/cookie.pxd
@@ -1,0 +1,6 @@
+# cython: language_level=3
+"""Public declaration of CookieExtractor — enables `cimport` from parameters.pyx."""
+
+
+cdef class CookieExtractor:
+    cpdef extract(self, object descriptor, object request)

--- a/tachyon_api/processing/_extractors/cookie.pyx
+++ b/tachyon_api/processing/_extractors/cookie.pyx
@@ -7,7 +7,7 @@ from ._missing import missing
 cdef class CookieExtractor:
     """Extracts a single cookie value by name."""
 
-    def extract(self, descriptor, request):
+    cpdef extract(self, object descriptor, object request):
         value = request.cookies.get(descriptor.effective_name)
         if value is not None:
             return (value, None)

--- a/tachyon_api/processing/_extractors/header.pxd
+++ b/tachyon_api/processing/_extractors/header.pxd
@@ -1,0 +1,12 @@
+# cython: language_level=3
+"""Public declaration of HeaderExtractor — enables `cimport` from parameters.pyx.
+
+A `cpdef` method visible at C level means callers can do a direct extension-type
+slot call instead of going through Python's method dispatch.  Phase 4b.2 left
+the call going through Python (`cdef object` reference + `def extract`); this
+recovers the ~30-60 ns/call overhead.
+"""
+
+
+cdef class HeaderExtractor:
+    cpdef extract(self, object descriptor, object request)

--- a/tachyon_api/processing/_extractors/header.pyx
+++ b/tachyon_api/processing/_extractors/header.pyx
@@ -11,7 +11,7 @@ from ._missing import missing
 cdef class HeaderExtractor:
     """Extracts a single header value by its canonical name."""
 
-    def extract(self, descriptor, request):
+    cpdef extract(self, object descriptor, object request):
         value = request.headers.get(descriptor.effective_name)
         if value is not None:
             return (value, None)

--- a/tachyon_api/processing/_extractors/path.pxd
+++ b/tachyon_api/processing/_extractors/path.pxd
@@ -1,0 +1,6 @@
+# cython: language_level=3
+"""Public declaration of PathExtractor — enables `cimport` from parameters.pyx."""
+
+
+cdef class PathExtractor:
+    cpdef extract(self, object descriptor, object path_params)

--- a/tachyon_api/processing/_extractors/path.pyx
+++ b/tachyon_api/processing/_extractors/path.pyx
@@ -55,7 +55,7 @@ cdef object _fast_float_path(str s):
 cdef class PathExtractor:
     """Extracts a path parameter, with null-byte rejection and type conversion."""
 
-    def extract(self, descriptor, path_params):
+    cpdef extract(self, object descriptor, object path_params):
         cdef str name = descriptor.name
         cdef str value_str
         cdef object base_type

--- a/tachyon_api/processing/_extractors/query.pxd
+++ b/tachyon_api/processing/_extractors/query.pxd
@@ -1,0 +1,6 @@
+# cython: language_level=3
+"""Public declaration of QueryExtractor — enables `cimport` from parameters.pyx."""
+
+
+cdef class QueryExtractor:
+    cpdef extract(self, object descriptor, object query_params)

--- a/tachyon_api/processing/_extractors/query.pyx
+++ b/tachyon_api/processing/_extractors/query.pyx
@@ -54,7 +54,7 @@ cdef object _fast_float(str s):
 cdef class QueryExtractor:
     """Extracts a single scalar query parameter and converts to its declared type."""
 
-    def extract(self, descriptor, query_params):
+    cpdef extract(self, object descriptor, object query_params):
         cdef str name = descriptor.name
         cdef str raw_val
         cdef object base_type

--- a/tachyon_api/processing/parameters.pyx
+++ b/tachyon_api/processing/parameters.pyx
@@ -21,10 +21,17 @@ from starlette.responses import JSONResponse
 from ..responses import validation_error_response
 from ..utils import TypeConverter, TypeUtils
 from ..background import BackgroundTasks
-from ._extractors.header import HeaderExtractor
-from ._extractors.cookie import CookieExtractor
-from ._extractors.query import QueryExtractor
-from ._extractors.path import PathExtractor
+# Python imports for instantiation
+from ._extractors.header import HeaderExtractor as _HeaderExtractor_py
+from ._extractors.cookie import CookieExtractor as _CookieExtractor_py
+from ._extractors.query import QueryExtractor as _QueryExtractor_py
+from ._extractors.path import PathExtractor as _PathExtractor_py
+
+# C-level cimport — enables direct cdef class slot dispatch (Phase 4b.3).
+from ._extractors.header cimport HeaderExtractor
+from ._extractors.cookie cimport CookieExtractor
+from ._extractors.query cimport QueryExtractor
+from ._extractors.path cimport PathExtractor
 from .compiler import (
     KIND_REQUEST, KIND_BG, KIND_BODY, KIND_QUERY,
     KIND_HEADER, KIND_COOKIE, KIND_FORM, KIND_FILE,
@@ -51,20 +58,30 @@ cdef int _DEFAULT_MAX_BODY_SIZE = 2 * 1024 * 1024  # 2 MB — matches parameters
 
 
 cdef class ParameterProcessor:
-    """Parameter extractor — orchestrator that delegates to cdef extractors."""
+    """Parameter extractor — orchestrator that delegates to cdef extractors.
+
+    The four migrated extractors are stored as typed cdef class references
+    (not generic `cdef object`).  Combined with the `cpdef extract(...)`
+    signature declared in each extractor's `.pxd`, this turns the dispatch
+    `self._header_extractor.extract(...)` into a direct C slot call —
+    recovers the ~60-120 ns/req of cross-module Python dispatch overhead
+    introduced in Phase 4b.2.
+    """
 
     cdef object app
-    cdef object _header_extractor
-    cdef object _cookie_extractor
-    cdef object _query_extractor
-    cdef object _path_extractor
+    cdef HeaderExtractor _header_extractor
+    cdef CookieExtractor _cookie_extractor
+    cdef QueryExtractor _query_extractor
+    cdef PathExtractor _path_extractor
 
     def __init__(self, app_instance):
         self.app = app_instance
-        self._header_extractor = HeaderExtractor()
-        self._cookie_extractor = CookieExtractor()
-        self._query_extractor = QueryExtractor()
-        self._path_extractor = PathExtractor()
+        # Use the Python-imported aliases to instantiate (cimport names refer
+        # only to the C-level type, not callable as a constructor here).
+        self._header_extractor = _HeaderExtractor_py()
+        self._cookie_extractor = _CookieExtractor_py()
+        self._query_extractor = _QueryExtractor_py()
+        self._path_extractor = _PathExtractor_py()
 
     async def process_parameters(self, compiled, request, dependency_cache):
         # Pre-allocate exact-size list — C array under the hood in CPython.


### PR DESCRIPTION
## Summary — v1.2.9 Phase 4b.3/7

Phase 4b.2 introduced cross-module cdef dispatch overhead because \`parameters.pyx\` held extractor instances as \`cdef object\` (untyped) — each call went through Python's method machinery. This phase adds \`.pxd\` declarations + \`cimport\` for typed C-level references → direct extension-type slot dispatch.

## Added (4 new \`.pxd\` files)

| File | Declares |
|---|---|
| \`_extractors/header.pxd\` | \`cdef class HeaderExtractor\` + \`cpdef extract\` |
| \`_extractors/cookie.pxd\` | \`cdef class CookieExtractor\` + \`cpdef extract\` |
| \`_extractors/query.pxd\` | \`cdef class QueryExtractor\` + \`cpdef extract\` |
| \`_extractors/path.pxd\` | \`cdef class PathExtractor\` + \`cpdef extract\` |

## Changed

- Each extractor \`.pyx\`: \`def extract(...)\` → \`cpdef extract(self, object descriptor, object source)\` (cpdef required to match .pxd).
- \`parameters.pyx\`:
  - \`cimport\` each extractor class for the C-level type
  - Renamed Python imports to \`_X_py\` aliases for instantiation
  - Extractor fields typed as cdef class instead of \`cdef object\`
  - Cython now generates direct slot dispatch for \`self._header_extractor.extract(...)\`

## Measurements (10-run median, compiled mode)

| Metric | Phase 4b.2 | Phase 4b.3 | Δ vs 4b.2 | Δ vs v1.2.83 baseline |
|---|---:|---:|---:|---:|
| **FULL HANDLER cycle** | 0.965 µs | **0.95 µs** | −1.5% | **−9.5%** |
| \`process_parameters\` — path+query | 0.635 µs | **0.595 µs** | **−6.3%** | +4.4% |
| body POST / no params | unchanged | unchanged | — | — |

The path+query regression dropped from +11.4% (4b.2) to +4.4% (4b.3) vs the v1.2.83 baseline.  Remaining gap is \`descriptor.*\` Python attribute access inside the extractors.

## Verification

- ✅ 366/367 tests pass with \`.so\` loaded
- ✅ 366/367 tests pass without \`.so\` (\`.pxd\` is Cython-only)
- ✅ F11 fast-int/fast-float preserved end-to-end

## Sprint status

**FULL HANDLER 0.95 µs median = conservative target met** (per \`docs/cython-plan-v1.2.9.md\`).

Remaining: Phase 4c (body/form/file/query_list to cdef), Phase 5 (nogil bearer), Phase 6 (fix known-failing tests), Phase 7 (CI matrix).