### PR TITLE
perf(v1.2.98): Phase 4c/7 — remaining extractors as cdef; parameters.pyx = pure orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.98] — 2026-05-22
+
+**v1.2.9 Cython sprint — Phase 4c/7: remaining four extractors migrated to
+cdef classes; `parameters.pyx` is now pure orchestrator.**
+
+The orchestrator inlined `_process_body`, `_process_form`, `_process_file`,
+and `_process_query_list` until this phase.  Phase 4c moves all four into
+their own compiled cdef-class extractors (sibling to header/cookie/query/path
+from Phase 4b), plus the `BodySizeChecker` helper used by body — and deletes
+the inline methods from `parameters.pyx` entirely.
+
+### Added
+
+- `processing/_extractors/body.pyx` + `.pxd` — `cdef class BodyExtractor`
+  with `async def extract`; size checking delegates to a `cimport`-ed
+  `BodySizeChecker`.
+- `processing/_extractors/body_limit.pyx` + `.pxd` — `cdef class
+  BodySizeChecker` with `cpdef check_content_length` /
+  `cpdef check_body_length` and a `cdef inline _too_large_response` helper.
+- `processing/_extractors/form.pyx` + `.pxd` — `cdef class FormExtractor`
+  with `cpdef extract`.
+- `processing/_extractors/file.pyx` + `.pxd` — `cdef class FileExtractor`
+  with `cpdef extract`.
+- `processing/_extractors/query_list.pyx` + `.pxd` — `cdef class
+  QueryListExtractor` with `cpdef extract`; handles both repeated keys and
+  CSV form, then delegates to `TypeConverter.convert_list_values_bare`.
+
+### Changed
+
+- `processing/parameters.pyx`:
+  - Deleted four inline helper methods (`_process_body`, `_process_form`,
+    `_process_file`, `_process_query_list`).
+  - Added `cimport` + Python alias import for the four new extractors.
+  - `ParameterProcessor` now holds **eight** typed cdef-class extractors as
+    fields, instantiated once in `__init__` (body extractor receives
+    `max_body_size` at construction, matching the pure-Python
+    `parameters.py` semantics).
+  - The orchestrator loop is now a straight dispatch: read `kind`, call
+    the matching extractor, unpack `(value, error)`.
+- `setup.py`: five new `Extension` entries (body, body_limit, form, file,
+  query_list).  Total compiled modules: 26.
+
+### Measurements (10-run median, compiled mode)
+
+| Metric | Phase 4b.3 | Phase 4c | Δ vs 4b.3 | Δ vs v1.2.83 baseline |
+|---|---:|---:|---:|---:|
+| **FULL HANDLER cycle** | 0.95 µs | **0.94 µs** | −1.1% | **−10.5%** |
+| `process_parameters` — path+query | 0.595 µs | **0.58 µs** | −2.5% | +1.8% |
+| `process_parameters` — body POST | — | 0.77 µs | — | — |
+| `process_parameters` — no params | 0.16 µs | 0.16 µs | unchanged | unchanged |
+
+path+query is now within 1.8% of the pre-SRP baseline (0.57 µs).  The
+architectural win is bigger than the per-metric delta: `parameters.pyx`
+went from a ~265-line monolith with four inline `_process_*` methods to a
+~175-line pure dispatch loop.
+
+### Verification
+
+- 366/367 framework tests pass with `.so` loaded.
+- 366/367 tests pass without `.so` (pure-Python fallback).
+- 1 known-failing CLI test (`test_new_creates_project_structure`) is
+  pre-existing — tracked for Phase 6.
+- Body-size limit semantics preserved (v1.2.85 hardening: 2 MB default;
+  `Tachyon(max_body_size=...)` override).
+- F11 fast-int/fast-float preserved end-to-end.
+
+### Sprint status
+
+After Phase 4c, the v1.2.9 sprint sits at **0.94 µs FULL HANDLER median**
+(−10.5% vs v1.2.83 baseline) with full SRP in compiled mode.  Remaining
+phases: F5 (nogil bearer parser, optional), F6 (fix the known-failing
+test), F7 (no-`.so` CI matrix + parity check).
+
+---
+
 ## [1.2.97] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 4b.3/7: `.pxd` declarations + `cimport` recover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.97"
+version = "1.2.98"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,32 @@ try:
             sources=["tachyon_api/processing/_extractors/path.pyx"],
             extra_compile_args=extra_compile_args,
         ),
+        # v1.2.98 — Phase 4c: remaining extractors as cdef class.
+        Extension(
+            "tachyon_api.processing._extractors.body_limit",
+            sources=["tachyon_api/processing/_extractors/body_limit.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing._extractors.body",
+            sources=["tachyon_api/processing/_extractors/body.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing._extractors.form",
+            sources=["tachyon_api/processing/_extractors/form.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing._extractors.file",
+            sources=["tachyon_api/processing/_extractors/file.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
+        Extension(
+            "tachyon_api.processing._extractors.query_list",
+            sources=["tachyon_api/processing/_extractors/query_list.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
     ]
 
     setup(

--- a/tachyon_api/processing/_extractors/body.pxd
+++ b/tachyon_api/processing/_extractors/body.pxd
@@ -1,0 +1,15 @@
+# cython: language_level=3
+"""Public declaration of BodyExtractor — enables `cimport` from parameters.pyx.
+
+`extract` is `async def`, not `cpdef`, because Cython does not expose async
+methods through cpdef.  Cross-module dispatch on the call still goes through
+Python machinery, but it's dominated by `await request.body()` I/O — typing
+the attribute via cimport still wins by skipping the per-call attribute
+lookup on `self._body_extractor`.
+"""
+
+from .body_limit cimport BodySizeChecker
+
+
+cdef class BodyExtractor:
+    cdef BodySizeChecker _size_check

--- a/tachyon_api/processing/_extractors/body.pyx
+++ b/tachyon_api/processing/_extractors/body.pyx
@@ -1,0 +1,60 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled body extractor.
+
+Reads the request body (size-validated) and decodes it with msgspec.
+The size checker is `cimport`-ed for typed C-level dispatch.
+"""
+
+import msgspec
+
+from ...responses import validation_error_response
+from .body_limit cimport BodySizeChecker
+
+
+cdef class BodyExtractor:
+    """Reads request body and decodes with msgspec.json.Decoder."""
+
+    def __init__(self, max_body_size):
+        self._size_check = BodySizeChecker(max_body_size)
+
+    async def extract(self, descriptor, request):
+        """Returns `(value, error)` plain tuple."""
+        err = self._size_check.check_content_length(request)
+        if err is not None:
+            return (None, err)
+
+        try:
+            raw_body = await request.body()
+        except Exception:
+            return (None, validation_error_response("Failed to read request body"))
+
+        err = self._size_check.check_body_length(raw_body)
+        if err is not None:
+            return (None, err)
+
+        return _decode(raw_body, descriptor.decoder)
+
+
+cdef _decode(bytes raw_body, object decoder):
+    if decoder is None:
+        return (None, validation_error_response("Body type must be a Struct subclass"))
+    try:
+        return (decoder.decode(raw_body), None)
+    except msgspec.DecodeError as e:
+        return (None, validation_error_response(f"Invalid JSON body: {e}"))
+    except msgspec.ValidationError as e:
+        return (None, _msgspec_validation_response(e))
+
+
+cdef _msgspec_validation_response(object e):
+    cdef object field_errors = None
+    try:
+        path = getattr(e, "path", None)
+        if path:
+            for seg in reversed(path):
+                if isinstance(seg, str):
+                    field_errors = {seg: [str(e)]}
+                    break
+    except Exception:
+        pass
+    return validation_error_response(str(e), errors=field_errors)

--- a/tachyon_api/processing/_extractors/body_limit.pxd
+++ b/tachyon_api/processing/_extractors/body_limit.pxd
@@ -1,0 +1,10 @@
+# cython: language_level=3
+"""Public declaration of BodySizeChecker — enables `cimport` from body.pyx."""
+
+
+cdef class BodySizeChecker:
+    cdef Py_ssize_t _max
+
+    cpdef check_content_length(self, object request)
+    cpdef check_body_length(self, bytes body)
+    cdef inline object _too_large_response(self)

--- a/tachyon_api/processing/_extractors/body_limit.pyx
+++ b/tachyon_api/processing/_extractors/body_limit.pyx
@@ -1,0 +1,38 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled body size validation.
+
+Two-pass: header pre-flight (`check_content_length`) + post-read
+(`check_body_length`).  cdef class with cpdef methods — direct C slot
+dispatch when called from body.pyx via cimport.
+"""
+
+from ...responses import validation_error_response
+
+
+cdef class BodySizeChecker:
+    """Answers: "is this request body within the configured size limit?" """
+
+    def __init__(self, max_body_size):
+        self._max = max_body_size
+
+    cpdef check_content_length(self, object request):
+        cdef object cl = request.headers.get("content-length")
+        cdef long parsed
+        if cl is not None:
+            try:
+                parsed = int(cl)
+                if parsed > self._max:
+                    return self._too_large_response()
+            except ValueError:
+                pass
+        return None
+
+    cpdef check_body_length(self, bytes body):
+        if len(body) > self._max:
+            return self._too_large_response()
+        return None
+
+    cdef inline object _too_large_response(self):
+        return validation_error_response(
+            f"Request body too large (max {self._max} bytes)"
+        )

--- a/tachyon_api/processing/_extractors/file.pxd
+++ b/tachyon_api/processing/_extractors/file.pxd
@@ -1,0 +1,6 @@
+# cython: language_level=3
+"""Public declaration of FileExtractor — enables `cimport` from parameters.pyx."""
+
+
+cdef class FileExtractor:
+    cpdef extract(self, object descriptor, object form_data)

--- a/tachyon_api/processing/_extractors/file.pyx
+++ b/tachyon_api/processing/_extractors/file.pyx
@@ -1,0 +1,23 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled uploaded-file extractor."""
+
+from ...responses import validation_error_response
+from ._missing import missing
+
+
+cdef class FileExtractor:
+    """Extracts an UploadFile from form data and validates the filename attribute."""
+
+    cpdef extract(self, object descriptor, object form_data):
+        cdef str name = descriptor.effective_name
+        if name not in form_data:
+            return missing(descriptor, "file", name)
+
+        uploaded = form_data[name]
+        if hasattr(uploaded, "filename"):
+            return (uploaded, None)
+
+        # Present but not a file — fall back to default or 422
+        if descriptor.default is not ...:
+            return (descriptor.default, None)
+        return (None, validation_error_response(f"Invalid file upload for: {name}"))

--- a/tachyon_api/processing/_extractors/form.pxd
+++ b/tachyon_api/processing/_extractors/form.pxd
@@ -1,0 +1,6 @@
+# cython: language_level=3
+"""Public declaration of FormExtractor — enables `cimport` from parameters.pyx."""
+
+
+cdef class FormExtractor:
+    cpdef extract(self, object descriptor, object form_data)

--- a/tachyon_api/processing/_extractors/form.pyx
+++ b/tachyon_api/processing/_extractors/form.pyx
@@ -1,0 +1,14 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled form-field extractor."""
+
+from ._missing import missing
+
+
+cdef class FormExtractor:
+    """Extracts a single form-field value."""
+
+    cpdef extract(self, object descriptor, object form_data):
+        cdef str name = descriptor.effective_name
+        if name in form_data:
+            return (form_data[name], None)
+        return missing(descriptor, "form field", name)

--- a/tachyon_api/processing/_extractors/query_list.pxd
+++ b/tachyon_api/processing/_extractors/query_list.pxd
@@ -1,0 +1,6 @@
+# cython: language_level=3
+"""Public declaration of QueryListExtractor — enables `cimport` from parameters.pyx."""
+
+
+cdef class QueryListExtractor:
+    cpdef extract(self, object descriptor, object query_params)

--- a/tachyon_api/processing/_extractors/query_list.pyx
+++ b/tachyon_api/processing/_extractors/query_list.pyx
@@ -1,0 +1,43 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""HOT PATH — Cython-compiled list-valued query parameter extractor.
+
+Supports both repeated keys (?id=1&id=2) and CSV form (?id=1,2,3).
+"""
+
+from starlette.responses import JSONResponse
+
+from ...utils import TypeConverter
+from ._missing import missing
+
+
+cdef class QueryListExtractor:
+    """Extracts a list query parameter, handling repeated keys and CSV values."""
+
+    cpdef extract(self, object descriptor, object query_params):
+        cdef str name = descriptor.name
+        cdef list values = []
+        cdef object v
+
+        raw_values = query_params.getlist(name)
+        if not raw_values and name in query_params:
+            raw_values = [query_params[name]]
+
+        for v in raw_values:
+            if isinstance(v, str) and "," in v:
+                values.extend((<str>v).split(","))
+            else:
+                values.append(v)
+
+        if not values:
+            return missing(descriptor, "query parameter", name)
+
+        converted = TypeConverter.convert_list_values_bare(
+            values,
+            descriptor.item_type,
+            descriptor.item_is_optional,
+            name,
+            is_path_param=False,
+        )
+        if isinstance(converted, JSONResponse):
+            return (None, converted)
+        return (converted, None)

--- a/tachyon_api/processing/parameters.pyx
+++ b/tachyon_api/processing/parameters.pyx
@@ -1,43 +1,50 @@
 # cython: language_level=3, boundscheck=False, wraparound=False
 """
-Cython-compiled parameter processor — Phase 4b.2 of v1.2.9.
+Cython-compiled parameter processor — Phase 4c of v1.2.9.
 
-Orchestrator that delegates to the cdef-class extractors compiled in Phase 4a:
-  HeaderExtractor · CookieExtractor · QueryExtractor (scalar) · PathExtractor.
+Orchestrator that delegates to the eight cdef-class extractors:
+  HeaderExtractor · CookieExtractor · QueryExtractor (scalar) · PathExtractor
+  BodyExtractor · FormExtractor · FileExtractor · QueryListExtractor.
 
-Extractors still inlined here (Phase 4c targets):
-  _process_body / _process_form / _process_file / _process_query (list path).
+No more inline `_process_*` methods.  This file is now purely a dispatch loop:
+read `kind`, call the matching extractor, unpack `(value, error)`.
 
-F11 fast-int / fast-float has moved into `query.pyx` and `path.pyx`
-(Phase 4b.1).  This file no longer carries the inline strtol/strtod helpers.
+F11 fast-int / fast-float live in `query.pyx` and `path.pyx`.
+Body size limit is captured in BodyExtractor at construction time.
 """
 
 import cython
-import msgspec
-import typing
 
 from starlette.responses import JSONResponse
 
 from ..responses import validation_error_response
-from ..utils import TypeConverter, TypeUtils
 from ..background import BackgroundTasks
+
 # Python imports for instantiation
 from ._extractors.header import HeaderExtractor as _HeaderExtractor_py
 from ._extractors.cookie import CookieExtractor as _CookieExtractor_py
 from ._extractors.query import QueryExtractor as _QueryExtractor_py
 from ._extractors.path import PathExtractor as _PathExtractor_py
+from ._extractors.body import BodyExtractor as _BodyExtractor_py
+from ._extractors.form import FormExtractor as _FormExtractor_py
+from ._extractors.file import FileExtractor as _FileExtractor_py
+from ._extractors.query_list import QueryListExtractor as _QueryListExtractor_py
 
-# C-level cimport — enables direct cdef class slot dispatch (Phase 4b.3).
+# C-level cimport — direct cdef class slot dispatch (Phase 4b.3 + 4c).
 from ._extractors.header cimport HeaderExtractor
 from ._extractors.cookie cimport CookieExtractor
 from ._extractors.query cimport QueryExtractor
 from ._extractors.path cimport PathExtractor
+from ._extractors.body cimport BodyExtractor
+from ._extractors.form cimport FormExtractor
+from ._extractors.file cimport FileExtractor
+from ._extractors.query_list cimport QueryListExtractor
+
 from .compiler import (
     KIND_REQUEST, KIND_BG, KIND_BODY, KIND_QUERY,
     KIND_HEADER, KIND_COOKIE, KIND_FORM, KIND_FILE,
     KIND_PATH, KIND_PATH_IMPLICIT, KIND_DEP_CALLABLE, KIND_DEP_CLASS,
 )
-from .scope import TachyonScope
 
 
 # C-level integer constants — avoids Python object lookup on each comparison
@@ -58,30 +65,36 @@ cdef int _DEFAULT_MAX_BODY_SIZE = 2 * 1024 * 1024  # 2 MB — matches parameters
 
 
 cdef class ParameterProcessor:
-    """Parameter extractor — orchestrator that delegates to cdef extractors.
+    """Parameter orchestrator — delegates to typed cdef-class extractors.
 
-    The four migrated extractors are stored as typed cdef class references
-    (not generic `cdef object`).  Combined with the `cpdef extract(...)`
-    signature declared in each extractor's `.pxd`, this turns the dispatch
-    `self._header_extractor.extract(...)` into a direct C slot call —
-    recovers the ~60-120 ns/req of cross-module Python dispatch overhead
-    introduced in Phase 4b.2.
+    All eight extractors are stored as typed cdef-class references.  Combined
+    with `cpdef extract(...)` declared in each `.pxd` (or `async def` for the
+    body extractor), Cython emits direct C slot dispatch on every call.
     """
 
     cdef object app
-    cdef HeaderExtractor _header_extractor
-    cdef CookieExtractor _cookie_extractor
-    cdef QueryExtractor _query_extractor
-    cdef PathExtractor _path_extractor
+    cdef HeaderExtractor _header
+    cdef CookieExtractor _cookie
+    cdef QueryExtractor _query
+    cdef PathExtractor _path
+    cdef BodyExtractor _body
+    cdef FormExtractor _form
+    cdef FileExtractor _file
+    cdef QueryListExtractor _query_list
 
     def __init__(self, app_instance):
+        cdef int max_body_size = getattr(app_instance, "max_body_size", _DEFAULT_MAX_BODY_SIZE)
         self.app = app_instance
-        # Use the Python-imported aliases to instantiate (cimport names refer
-        # only to the C-level type, not callable as a constructor here).
-        self._header_extractor = _HeaderExtractor_py()
-        self._cookie_extractor = _CookieExtractor_py()
-        self._query_extractor = _QueryExtractor_py()
-        self._path_extractor = _PathExtractor_py()
+        # Use the Python-imported aliases for instantiation (cimport names
+        # refer only to the C-level type, not callable as constructor here).
+        self._header = _HeaderExtractor_py()
+        self._cookie = _CookieExtractor_py()
+        self._query = _QueryExtractor_py()
+        self._path = _PathExtractor_py()
+        self._body = _BodyExtractor_py(max_body_size)
+        self._form = _FormExtractor_py()
+        self._file = _FileExtractor_py()
+        self._query_list = _QueryListExtractor_py()
 
     async def process_parameters(self, compiled, request, dependency_cache):
         # Pre-allocate exact-size list — C array under the hood in CPython.
@@ -114,31 +127,28 @@ cdef class ParameterProcessor:
                 args[i] = self.app._dependency_resolver.resolve_dependency(p.annotation)
 
             elif kind == _KIND_BODY:
-                # Phase 4c — still inline
-                val, err = await self._process_body(p, request)
+                val, err = await self._body.extract(p, request)
                 if err is not None:
                     return args, err, _bg
                 args[i] = val
 
             elif kind == _KIND_QUERY:
-                # Delegate scalar to QueryExtractor (cdef class with F11).
-                # List path stays inline until Phase 4c brings query_list.pyx in.
                 if p.is_list:
-                    val, err = self._process_query_list(p, request.query_params)
+                    val, err = self._query_list.extract(p, request.query_params)
                 else:
-                    val, err = self._query_extractor.extract(p, request.query_params)
+                    val, err = self._query.extract(p, request.query_params)
                 if err is not None:
                     return args, err, _bg
                 args[i] = val
 
             elif kind == _KIND_HEADER:
-                val, err = self._header_extractor.extract(p, request)
+                val, err = self._header.extract(p, request)
                 if err is not None:
                     return args, err, _bg
                 args[i] = val
 
             elif kind == _KIND_COOKIE:
-                val, err = self._cookie_extractor.extract(p, request)
+                val, err = self._cookie.extract(p, request)
                 if err is not None:
                     return args, err, _bg
                 args[i] = val
@@ -149,7 +159,7 @@ cdef class ParameterProcessor:
                         _form_data = await request.form()
                     except Exception:
                         return args, validation_error_response("Failed to parse form data"), _bg
-                val, err = self._process_form(p, _form_data)
+                val, err = self._form.extract(p, _form_data)
                 if err is not None:
                     return args, err, _bg
                 args[i] = val
@@ -160,15 +170,13 @@ cdef class ParameterProcessor:
                         _form_data = await request.form()
                     except Exception:
                         return args, validation_error_response("Failed to parse form data"), _bg
-                val, err = self._process_file(p, _form_data)
+                val, err = self._file.extract(p, _form_data)
                 if err is not None:
                     return args, err, _bg
                 args[i] = val
 
             elif kind == _KIND_PATH or kind == _KIND_PATH_IMPLICIT:
-                # Delegate to PathExtractor — handles scalar (F11 fast int/float)
-                # and list (TypeConverter), plus the null-byte security check.
-                val, err = self._path_extractor.extract(p, request.path_params)
+                val, err = self._path.extract(p, request.path_params)
                 if err is not None:
                     return args, err, _bg
                 args[i] = val
@@ -176,90 +184,3 @@ cdef class ParameterProcessor:
             i += 1
 
         return args, None, _bg
-
-    # ── still-inline helpers (Phase 4c migrates these out) ────────────────────
-
-    async def _process_body(self, p, request):
-        cdef int max_body_size = getattr(self.app, "max_body_size", _DEFAULT_MAX_BODY_SIZE)
-        cdef object cl = request.headers.get("content-length")
-        if cl is not None:
-            try:
-                if int(cl) > max_body_size:
-                    return None, validation_error_response(
-                        f"Request body too large (max {max_body_size} bytes)"
-                    )
-            except ValueError:
-                pass
-        try:
-            raw_body = await request.body()
-        except Exception:
-            return None, validation_error_response("Failed to read request body")
-        if len(raw_body) > max_body_size:
-            return None, validation_error_response(
-                f"Request body too large (max {max_body_size} bytes)"
-            )
-        cdef object decoder = p.decoder
-        if decoder is None:
-            return None, validation_error_response("Body type must be a Struct subclass")
-        try:
-            return decoder.decode(raw_body), None
-        except msgspec.DecodeError as e:
-            return None, validation_error_response(f"Invalid JSON body: {e}")
-        except msgspec.ValidationError as e:
-            field_errors = None
-            try:
-                path_attr = getattr(e, "path", None)
-                if path_attr:
-                    for seg in reversed(path_attr):
-                        if isinstance(seg, str):
-                            field_errors = {seg: [str(e)]}
-                            break
-            except Exception:
-                pass
-            return None, validation_error_response(str(e), errors=field_errors)
-
-    @cython.cfunc
-    def _process_query_list(self, p, query_params):
-        cdef str name = p.name
-        raw_values = query_params.getlist(name)
-        if not raw_values and name in query_params:
-            raw_values = [query_params[name]]
-        values = []
-        for v in raw_values:
-            if isinstance(v, str) and "," in v:
-                values.extend(v.split(","))
-            else:
-                values.append(v)
-        if not values:
-            if p.default is not ...:
-                return p.default, None
-            return None, validation_error_response(f"Missing required query parameter: {name}")
-        converted = TypeConverter.convert_list_values_bare(
-            values, p.item_type, p.item_is_optional, name, is_path_param=False
-        )
-        if isinstance(converted, JSONResponse):
-            return None, converted
-        return converted, None
-
-    @cython.cfunc
-    def _process_form(self, p, form_data):
-        cdef str name = p.effective_name
-        if name in form_data:
-            return form_data[name], None
-        elif p.default is not ...:
-            return p.default, None
-        return None, validation_error_response(f"Missing required form field: {name}")
-
-    @cython.cfunc
-    def _process_file(self, p, form_data):
-        cdef str name = p.effective_name
-        if name in form_data:
-            uploaded = form_data[name]
-            if hasattr(uploaded, "filename"):
-                return uploaded, None
-            elif p.default is not ...:
-                return p.default, None
-            return None, validation_error_response(f"Invalid file upload for: {name}")
-        elif p.default is not ...:
-            return p.default, None
-        return None, validation_error_response(f"Missing required file: {name}")


### PR DESCRIPTION
## Summary — v1.2.9 Phase 4c/7

Migrates the four extractors still inlined in \`parameters.pyx\` into their own compiled cdef-class modules, plus the \`BodySizeChecker\` helper used by body.  After this phase \`parameters.pyx\` is a straight dispatch loop — every extractor lives in its own \`.pyx/.pxd\` pair.

## Added (5 new compiled modules)

| Module | Type | Note |
|---|---|---|
| \`_extractors/body.pyx\` + \`.pxd\` | \`cdef class BodyExtractor\` | \`async def extract\` |
| \`_extractors/body_limit.pyx\` + \`.pxd\` | \`cdef class BodySizeChecker\` | \`cpdef\` size checks |
| \`_extractors/form.pyx\` + \`.pxd\` | \`cdef class FormExtractor\` | \`cpdef extract\` |
| \`_extractors/file.pyx\` + \`.pxd\` | \`cdef class FileExtractor\` | \`cpdef extract\` |
| \`_extractors/query_list.pyx\` + \`.pxd\` | \`cdef class QueryListExtractor\` | \`cpdef extract\` |

\`body.pyx\` \`cimport\`s \`BodySizeChecker\` — the two size checks per body request go through C-level slot dispatch.

## Changed

- **\`parameters.pyx\`**: deletes the four inline \`_process_*\` helpers (\`_process_body\`, \`_process_form\`, \`_process_file\`, \`_process_query_list\`). Holds **eight** typed cdef-class extractors as fields, instantiated once in \`__init__\`. \`BodyExtractor\` receives \`max_body_size\` at construction (matches \`parameters.py\`).
- **\`setup.py\`**: five new \`Extension\` entries. Total compiled modules now 26.

## Measurements (10-run median, compiled mode)

| Metric | Phase 4b.3 | Phase 4c | Δ vs 4b.3 | Δ vs v1.2.83 baseline |
|---|---:|---:|---:|---:|
| **FULL HANDLER cycle** | 0.95 µs | **0.94 µs** | −1.1% | **−10.5%** |
| \`process_parameters\` — path+query | 0.595 µs | **0.58 µs** | −2.5% | **+1.8%** |
| \`process_parameters\` — body POST | — | 0.77 µs | — | — |
| \`process_parameters\` — no params | 0.16 µs | 0.16 µs | unchanged | unchanged |

\`path+query\` is now within **1.8%** of the pre-SRP baseline (0.57 µs). The bigger win is architectural: \`parameters.pyx\` dropped from ~265 lines (4 inline \`_process_*\` methods) to ~175 lines of pure dispatch.

## Verification

- ✅ 366/367 tests pass with \`.so\` loaded
- ✅ 366/367 tests pass without \`.so\` (pure-Python fallback)
- ✅ Body size limit (v1.2.85 hardening: 2 MB default; \`Tachyon(max_body_size=...)\` override) preserved
- ✅ F11 fast-int/fast-float preserved end-to-end
- ⚠️ 1 known-failing CLI test (\`test_new_creates_project_structure\`) pre-existing — tracked for Phase 6

## Sprint status

After Phase 4c the v1.2.9 sprint sits at **0.94 µs FULL HANDLER median** (−10.5% vs v1.2.83 baseline) with full SRP visible in compiled mode.  Remaining phases:
- F5 — \`nogil\` bearer parser (optional)
- F6 — fix the known-failing test
- F7 — no-\`.so\` CI matrix + \`.py\` ↔ \`.pyx\` parity check