### PR TITLE
perf(v1.2.99): Phase 5/7 — compile parse_bearer_header to cdef module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.99] — 2026-05-22
+
+**v1.2.9 Cython sprint — Phase 5/7: Bearer header parser compiled.**
+
+`parse_bearer_header` is called by `HTTPBearer` and `OAuth2PasswordBearer`
+on every authenticated request — lukewarm path.  Compiling it to a cdef
+module yields a clean 1.6× speedup on the parser call itself, saving
+~100 ns per authenticated request.
+
+The v1.2.9 plan tagged Phase 5 as `nogil` + `memchr` (optional).  Hand-
+rolled whitespace scanning would diverge from `str.split()` on
+multi-whitespace / non-space whitespace inputs, so this commit ships the
+compile-only version.  A strict RFC 7235 token parser with `memchr` +
+`nogil` is left for v1.3.x.
+
+### Added
+
+- `security/_bearer_parser.pyx` — `cpdef parse_bearer_header` with typed
+  locals (`cdef list parts`, `cdef str scheme`).
+
+### Changed
+
+- `setup.py`: one new `Extension` (`tachyon_api.security._bearer_parser`).
+  Total compiled modules: 27.
+
+### Measurements
+
+`parse_bearer_header('Bearer <jwt-like-string>')` × 1 M iterations:
+
+| Variant | µs/call | call/s | Δ |
+|---|---:|---:|---:|
+| Pure-Python `.py` | 0.268 | 3.7 M | (baseline) |
+| Compiled `.pyx` | **0.166** | **6.0 M** | **1.61×** |
+
+FULL HANDLER cycle: 5-run median 0.95 µs — same band as Phase 4c, no
+regression (bearer is not on the FULL HANDLER bench path).
+
+### Verification
+
+- 366/367 tests pass with `.so` loaded.
+- 366/367 tests pass without `.so`.
+- Edge cases verified equivalent to pure-Python version: empty / None
+  input, single-part input, scheme ≠ "bearer", multi-whitespace
+  separators, tab separator, surrounding whitespace, 3-part input.
+
+---
+
 ## [1.2.98] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 4c/7: remaining four extractors migrated to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.98"
+version = "1.2.99"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,12 @@ try:
             sources=["tachyon_api/processing/_extractors/query_list.pyx"],
             extra_compile_args=extra_compile_args,
         ),
+        # v1.2.99 — Phase 5: Bearer header parser (lukewarm path).
+        Extension(
+            "tachyon_api.security._bearer_parser",
+            sources=["tachyon_api/security/_bearer_parser.pyx"],
+            extra_compile_args=extra_compile_args,
+        ),
     ]
 
     setup(

--- a/tachyon_api/security/_bearer_parser.pyx
+++ b/tachyon_api/security/_bearer_parser.pyx
@@ -1,0 +1,29 @@
+# cython: language_level=3, boundscheck=False, wraparound=False
+"""LUKEWARM PATH — Cython-compiled Bearer header parser.
+
+Called by HTTPBearer and OAuth2PasswordBearer on every authenticated
+request.  Semantics are identical to the pure-Python `_bearer_parser.py`
+(case-insensitive `bearer` + 2 whitespace-separated parts, any whitespace
+via `str.split()`).  cpdef + typed locals get C dispatch from the
+security middlewares; the costly `split()` call stays in CPython's C
+implementation either way.
+
+`nogil` + raw `memchr` parsing was on the v1.2.9 plan as "(optional)", but
+hand-rolling whitespace scanning would diverge from `str.split()` on
+multi-whitespace / non-space whitespace inputs.  The compile-only win is
+small but safe; the memchr path is left for v1.3.x once we own a strict
+RFC 7235 token parser.
+"""
+
+
+cpdef parse_bearer_header(authorization):
+    """Return (scheme, token) for a `Bearer <token>` header, or None if invalid."""
+    if not authorization:
+        return None
+    cdef list parts = authorization.split()
+    if len(parts) != 2:
+        return None
+    cdef str scheme = parts[0]
+    if scheme.lower() != "bearer":
+        return None
+    return scheme, parts[1]


### PR DESCRIPTION
## Summary — v1.2.9 Phase 5/7

\`parse_bearer_header\` is called by \`HTTPBearer\` and \`OAuth2PasswordBearer\` on every authenticated request — lukewarm path. Compiling it to a cdef module yields a clean **1.61× speedup** on the parser call itself, saving ~100 ns per authenticated request.

### Why not nogil + memchr

The v1.2.9 plan tagged Phase 5 as \`nogil\` + \`memchr\` (optional). Hand-rolled whitespace scanning would diverge from \`str.split()\` on multi-whitespace / non-space whitespace inputs (tab, \\r, \\n). This commit ships the compile-only version; a strict RFC 7235 token parser with \`memchr\` + \`nogil\` is deferred to v1.3.x.

### Added

- \`security/_bearer_parser.pyx\` — \`cpdef parse_bearer_header\` with typed locals (\`cdef list parts\`, \`cdef str scheme\`).

### Changed

- \`setup.py\`: +1 Extension. Total compiled modules: **27**.

### Measurements

\`parse_bearer_header('Bearer <jwt-like-string>')\` × 1 M iterations:

| Variant | µs/call | call/s | Δ |
|---|---:|---:|---:|
| Pure-Python \`.py\` | 0.268 | 3.7 M | (baseline) |
| Compiled \`.pyx\` | **0.166** | **6.0 M** | **1.61×** |

FULL HANDLER (5-run median): **0.95 µs** — same band as Phase 4c, no regression.

### Verification

- ✅ 366/367 tests pass with \`.so\` loaded
- ✅ 366/367 tests pass without \`.so\`
- ✅ Edge-case parity with pure-Python: None/empty input, 1-part input, scheme ≠ "bearer", multi-whitespace separators, tab, leading/trailing whitespace, 3-part input

### Sprint status

Remaining: F6 (fix 1 known-failing CLI test), F7 (no-\`.so\` CI matrix + \`.py\`↔\`.pyx\` parity check).