### PR TITLE
fix(v1.2.991): Phase 6/7 — update stale CLI test for validate_name normalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.991] — 2026-05-22
+
+**v1.2.9 Cython sprint — Phase 6/7: fix stale CLI test (suite now 367/367).**
+
+`test_new_creates_project_structure` had been red since the v1.2.81 sprint
+that added `validate_name` (hyphen → underscore normalisation, Python-keyword
+rejection).  The test still asserted on `Path(tmpdir) / "my-api"` while
+the CLI now creates `Path(tmpdir) / "my_api"` and prints a normalisation
+notice — the production code is correct, the test was outdated.
+
+### Fixed
+
+- `tests/test_cli.py::TestNewCommand::test_new_creates_project_structure`:
+  asserts the project lives at the normalised name (`my_api`) and that the
+  stdout shows both the input (`my-api`) and the normalised form
+  (`my_api`).
+
+### Result
+
+| | Before | After |
+|---|---:|---:|
+| Tests passing | 366/367 | **367/367** |
+| Tests failing | 1 | **0** |
+
+No production code changed in this phase — Phase 6 is purely a test fix.
+
+---
+
 ## [1.2.99] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 5/7: Bearer header parser compiled.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.99"
+version = "1.2.991"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,13 +13,16 @@ runner = CliRunner()
 
 class TestNewCommand:
     def test_new_creates_project_structure(self):
+        # `my-api` is normalised to `my_api` by `validate_name` (hyphens → underscores)
+        # so the project gets created under that Python-identifier-safe name.
         with tempfile.TemporaryDirectory() as tmpdir:
             result = runner.invoke(app, ["new", "my-api", "--path", tmpdir])
 
             assert result.exit_code == 0
             assert "Creating Tachyon project" in result.stdout
+            assert "my-api" in result.stdout and "my_api" in result.stdout
 
-            project_path = Path(tmpdir) / "my-api"
+            project_path = Path(tmpdir) / "my_api"
 
             # Check directories
             assert (project_path / "modules").exists()


### PR DESCRIPTION
## Summary — v1.2.9 Phase 6/7

\`test_new_creates_project_structure\` had been red since the v1.2.81 sprint that added \`validate_name\` (hyphen → underscore normalisation). The test asserted on \`Path(tmpdir) / \"my-api\"\` while the CLI correctly creates \`Path(tmpdir) / \"my_api\"\` and prints a normalisation notice — production code is right, the test was outdated.

## Updated

- \`tests/test_cli.py::TestNewCommand::test_new_creates_project_structure\`:
  - asserts the project lives at the normalised name (\`my_api\`)
  - asserts stdout shows both the input (\`my-api\`) and normalised form (\`my_api\`)

## Result

| | Before | After |
|---|---:|---:|
| Tests passing | 366/367 | **367/367** |
| Tests failing | 1 | **0** |

No production code changed in this phase — Phase 6 is purely a test fix.

## Sprint status

After Phase 6 the test suite is fully green.  Remaining: F7 (no-\`.so\` CI matrix + \`.py\`↔\`.pyx\` parity check).