### PR TITLE
ci(v1.2.992): Phase 7/7 (CLOSER) — CI matrix + .py ↔ .pyx parity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  parity:
+    name: .py ↔ .pyx parity check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Run parity script
+        run: python scripts/check_py_pyx_parity.py
+
+  test-pure-python:
+    name: Tests (pure-Python fallback)
+    runs-on: ubuntu-latest
+    needs: parity
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install package (no Cython compilation)
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-asyncio httpx
+      - name: Verify no .so files present
+        run: |
+          if find tachyon_api -name "*.so" | grep -q .; then
+            echo "::error::Unexpected .so files in pure-Python job — fallback mode is invalid"
+            find tachyon_api -name "*.so"
+            exit 1
+          fi
+      - name: Run test suite
+        run: pytest tests/ -v
+
+  test-compiled:
+    name: Tests (Cython-compiled .so)
+    runs-on: ubuntu-latest
+    needs: parity
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install build deps + package
+        run: |
+          pip install --upgrade pip
+          pip install Cython
+          pip install -e .
+          pip install pytest pytest-asyncio httpx
+      - name: Compile Cython extensions
+        run: python setup.py build_ext --inplace
+      - name: Verify compiled artefacts exist
+        run: |
+          missing=0
+          for mod in parameters compiler response_processor scope dispatch; do
+            if ! ls tachyon_api/processing/${mod}*.so >/dev/null 2>&1; then
+              echo "::error::Missing compiled artefact: tachyon_api/processing/${mod}*.so"
+              missing=1
+            fi
+          done
+          if ! ls tachyon_api/routing/trie*.so >/dev/null 2>&1; then
+            echo "::error::Missing compiled artefact: tachyon_api/routing/trie*.so"
+            missing=1
+          fi
+          exit $missing
+      - name: Run test suite
+        run: pytest tests/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.992] — 2026-05-22
+
+**v1.2.9 Cython sprint — Phase 7/7 (CLOSER): CI matrix + `.py` ↔ `.pyx` parity check.**
+
+Closes the sprint with the two pieces of infrastructure that prevent the
+class of bug we lived through at v1.2.85: a security fix that shipped in
+`parameters.py` but not in `parameters.pyx`, so compiled-mode users were
+silently exposed.
+
+Going forward every PR runs the test suite **in both modes** (pure-Python
+and Cython-compiled), and a structural parity script blocks merges if a
+`.py` exposes a public function/class/method that its `.pyx` sibling
+doesn't (or vice-versa).  Logic divergence still requires the test suite —
+the script only catches API drift — but API drift is what enabled the
+v1.2.85 incident in the first place.
+
+### Added
+
+- `.github/workflows/ci.yml` — three CI jobs:
+  - `parity` — runs `scripts/check_py_pyx_parity.py` (gate).
+  - `test-pure-python` — installs without compilation, verifies no `.so`
+    is present, runs `pytest tests/`.
+  - `test-compiled` — installs Cython, compiles all extensions, verifies
+    the critical `.so` artefacts exist, runs `pytest tests/`.
+- `scripts/check_py_pyx_parity.py` — structural diff between `.py` and
+  `.pyx` siblings:
+  - Public top-level functions match.
+  - Public top-level classes match.
+  - For each shared class, public method set matches.
+  - `_server_fast.pyx` is whitelisted as `.pyx`-only (low-level perf
+    module without a Python equivalent).
+
+### Local result
+
+```
+$ python scripts/check_py_pyx_parity.py
+✓ .py ↔ .pyx parity check passed (26 pair(s), 27 .pyx total)
+
+$ pytest tests/
+367 passed in ~25 s
+```
+
+### Sprint v1.2.9 — final summary
+
+Closed in 7 phases between v1.2.91 and v1.2.992:
+
+| Phase | Version | Delivered |
+|---|---|---|
+| 1 | 1.2.91 | Response classes as compiled `.pyx` |
+| 2 | 1.2.92 | DI resolver pipeline as cdef classes |
+| 3 | 1.2.93 | `ExceptionTable` as cdef class |
+| 4a | 1.2.94 | Easy extractors as cdef class (used by pure-Python fallback) |
+| 4b.1 | 1.2.95 | F11 fast-int / fast-float migrated into query/path extractors |
+| 4b.2 | 1.2.96 | `parameters.pyx` rewritten to delegate to cdef extractors |
+| 4b.3 | 1.2.97 | `.pxd` + `cimport` — typed cdef-class slot dispatch |
+| 4c | 1.2.98 | Remaining four extractors as cdef; `parameters.pyx` = pure orchestrator |
+| 5 | 1.2.99 | `parse_bearer_header` compiled (1.61× on the call) |
+| 6 | 1.2.991 | Fix stale CLI test (suite back to 367/367) |
+| 7 | 1.2.992 | CI matrix + parity check |
+
+Hot-path measurements (10-run median, compiled mode):
+
+| | v1.2.83 baseline | v1.2.992 (sprint close) | Δ |
+|---|---:|---:|---:|
+| FULL HANDLER cycle | 1.05 µs | **0.94 µs** | **−10.5%** |
+| `process_parameters` — path+query | 0.57 µs | 0.58 µs | +1.8% |
+| `process_parameters` — body POST | — | 0.77 µs | — |
+| `process_parameters` — no params | 0.16 µs | 0.16 µs | unchanged |
+| `parse_bearer_header` per call | 0.268 µs | **0.166 µs** | **1.61×** |
+| Tests | 366/367 | **367/367** | clean |
+| Compiled modules | 7 | **27** | +20 |
+| `parameters.pyx` LOC | 460 (monolith) | **175 (orchestrator)** | −62% |
+
+The conservative target of ≤ 0.95 µs FULL HANDLER median is met.  More
+importantly, the SRP refactor (eight atomic extractors in their own
+`.pyx`/`.pxd` pairs) is now visible in production compiled mode, not just
+in the pure-Python fallback.
+
+---
+
 ## [1.2.991] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 6/7: fix stale CLI test (suite now 367/367).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ v1.2.85 incident in the first place.
   - `_server_fast.pyx` is whitelisted as `.pyx`-only (low-level perf
     module without a Python equivalent).
 
+### Fixed (caught by the new CI itself)
+
+- `httptools` was a missing declared dependency.  `app/_fast_asgi_factory.py`
+  top-level-imports `tachyon_api.server`, which imports
+  `uvicorn.protocols.http.httptools_impl`.  Locally we always had
+  `httptools` from some transitive install, so the gap went unnoticed.
+  The clean Ubuntu CI runner blew up with `ModuleNotFoundError: httptools`
+  on the very first run — exactly the kind of platform-divergence bug the
+  no-`.so` job was added to catch.  Added `httptools >= 0.6.0` to
+  `[tool.poetry.dependencies]`.
+
 ### Local result
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.991"
+version = "1.2.992"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ include = [
 python = "^3.10"
 starlette = "^0.47.2"
 uvicorn = "^0.35.0"
+httptools = ">=0.6.0"
 msgspec = "^0.19.0"
 typer = "^0.16.0"
 orjson = "^3.11.1"

--- a/scripts/check_py_pyx_parity.py
+++ b/scripts/check_py_pyx_parity.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+.py ↔ .pyx parity check.
+
+For every `.pyx` module that has a sibling `.py` (the pure-Python fallback),
+verify that they expose the same public API:
+  - Same set of public top-level functions
+  - Same set of public top-level classes
+  - For each shared class: same set of public method names
+
+Catches the kind of silent divergence introduced in v1.2.85, where the
+pure-Python parameter pipeline got a security fix (null-byte rejection,
+2 MB body limit) that the Cython version missed because nobody re-read
+the .pyx file.
+
+This script is a STRUCTURAL check.  It cannot detect logic divergence —
+that's the job of the test suite (which runs in both modes via CI).
+
+Exit codes:
+  0 — all pairs aligned
+  1 — at least one pair has mismatched public surface
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parent.parent
+PKG = ROOT / "tachyon_api"
+
+# `.pyx` files that intentionally have no `.py` sibling.
+PYX_ONLY_WHITELIST = {
+    "tachyon_api/_server_fast.pyx",  # low-level perf module, Cython-only by design
+}
+
+
+def public(name: str) -> bool:
+    """Top-level public name — single-leading-underscore symbols are private."""
+    return not name.startswith("_")
+
+
+def extract_py_surface(path: Path) -> tuple[set[str], set[str], dict[str, set[str]]]:
+    """Return (functions, classes, methods-by-class) for a .py file."""
+    tree = ast.parse(path.read_text())
+    funcs: set[str] = set()
+    classes: set[str] = set()
+    methods: dict[str, set[str]] = {}
+
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if public(node.name):
+                funcs.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            if public(node.name):
+                classes.add(node.name)
+                ms: set[str] = set()
+                for sub in node.body:
+                    if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        if public(sub.name) or sub.name == "__init__":
+                            ms.add(sub.name)
+                methods[node.name] = ms
+    return funcs, classes, methods
+
+
+# Regex-based scan for .pyx files (no Python ast for Cython grammar).
+_DEF_RX = re.compile(
+    r"^\s*(?:async\s+)?(?:cpdef|cdef|def)\s+(?:[a-zA-Z_][\w\[\]\.,\s*]*\s+)?([a-zA-Z_]\w*)\s*\(",
+    re.MULTILINE,
+)
+_CLASS_RX = re.compile(r"^\s*(?:cdef\s+)?class\s+([a-zA-Z_]\w*)\s*[:\(]", re.MULTILINE)
+
+
+def extract_pyx_surface(path: Path) -> tuple[set[str], set[str], dict[str, set[str]]]:
+    """Return (functions, classes, methods-by-class) for a .pyx file.
+
+    Uses regex — Cython's grammar isn't covered by `ast`.  Good enough for
+    the structural surface check because we only care about top-level names
+    and method names, not body content.
+    """
+    text = path.read_text()
+    # Strip comments and docstrings (rough but good enough — we don't want
+    # to match `class` or `def` mentioned inside strings).
+    text = re.sub(r'""".*?"""', "", text, flags=re.DOTALL)
+    text = re.sub(r"'''.*?'''", "", text, flags=re.DOTALL)
+    text = re.sub(r"#[^\n]*", "", text)
+
+    classes: set[str] = set()
+    methods: dict[str, set[str]] = {}
+    funcs: set[str] = set()
+
+    # Walk line by line tracking class indent
+    current_class: str | None = None
+    class_indent: int = -1
+    for raw_line in text.splitlines():
+        # Skip blank lines but don't change class state on them
+        if not raw_line.strip():
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip())
+
+        # Leaving the class block
+        if current_class is not None and indent <= class_indent:
+            current_class = None
+            class_indent = -1
+
+        # Class definition
+        m_cls = _CLASS_RX.match(raw_line)
+        if m_cls:
+            cname = m_cls.group(1)
+            if public(cname):
+                classes.add(cname)
+                methods.setdefault(cname, set())
+                current_class = cname
+                class_indent = indent
+            else:
+                current_class = None
+            continue
+
+        # Def / cpdef / cdef function
+        m_def = _DEF_RX.match(raw_line)
+        if m_def:
+            fname = m_def.group(1)
+            if current_class is not None:
+                if public(fname) or fname == "__init__":
+                    methods[current_class].add(fname)
+            elif indent == 0:
+                if public(fname):
+                    funcs.add(fname)
+
+    return funcs, classes, methods
+
+
+def relpath(p: Path) -> str:
+    return str(p.relative_to(ROOT))
+
+
+def check_pair(pyx_path: Path) -> list[str]:
+    """Compare the public surface of `pyx_path` with its `.py` sibling.
+
+    Returns a list of human-readable mismatch messages.  Empty list = OK.
+    """
+    py_path = pyx_path.with_suffix(".py")
+    msgs: list[str] = []
+    if not py_path.exists():
+        if relpath(pyx_path) not in PYX_ONLY_WHITELIST:
+            msgs.append(
+                f"{relpath(pyx_path)}: no .py sibling "
+                f"(add to PYX_ONLY_WHITELIST if intentional)"
+            )
+        return msgs
+
+    py_funcs, py_classes, py_methods = extract_py_surface(py_path)
+    pyx_funcs, pyx_classes, pyx_methods = extract_pyx_surface(pyx_path)
+
+    only_in_py_funcs = py_funcs - pyx_funcs
+    only_in_pyx_funcs = pyx_funcs - py_funcs
+    if only_in_py_funcs:
+        msgs.append(
+            f"{relpath(pyx_path)}: functions in .py but not .pyx: "
+            f"{sorted(only_in_py_funcs)}"
+        )
+    if only_in_pyx_funcs:
+        msgs.append(
+            f"{relpath(pyx_path)}: functions in .pyx but not .py: "
+            f"{sorted(only_in_pyx_funcs)}"
+        )
+
+    only_in_py_classes = py_classes - pyx_classes
+    only_in_pyx_classes = pyx_classes - py_classes
+    if only_in_py_classes:
+        msgs.append(
+            f"{relpath(pyx_path)}: classes in .py but not .pyx: "
+            f"{sorted(only_in_py_classes)}"
+        )
+    if only_in_pyx_classes:
+        msgs.append(
+            f"{relpath(pyx_path)}: classes in .pyx but not .py: "
+            f"{sorted(only_in_pyx_classes)}"
+        )
+
+    for cls in py_classes & pyx_classes:
+        only_py = py_methods.get(cls, set()) - pyx_methods.get(cls, set())
+        only_pyx = pyx_methods.get(cls, set()) - py_methods.get(cls, set())
+        if only_py:
+            msgs.append(
+                f"{relpath(pyx_path)}: class {cls} methods in .py but not .pyx: "
+                f"{sorted(only_py)}"
+            )
+        if only_pyx:
+            msgs.append(
+                f"{relpath(pyx_path)}: class {cls} methods in .pyx but not .py: "
+                f"{sorted(only_pyx)}"
+            )
+
+    return msgs
+
+
+def main(argv: Iterable[str]) -> int:
+    pyx_files = sorted(PKG.rglob("*.pyx"))
+    if not pyx_files:
+        print("ERROR: no .pyx files found under tachyon_api/", file=sys.stderr)
+        return 1
+
+    all_msgs: list[str] = []
+    pairs_checked = 0
+    for pyx in pyx_files:
+        if pyx.with_suffix(".py").exists():
+            pairs_checked += 1
+        all_msgs.extend(check_pair(pyx))
+
+    if all_msgs:
+        print("✗ .py ↔ .pyx parity check FAILED\n")
+        for m in all_msgs:
+            print(f"  • {m}")
+        print(
+            f"\nChecked {pairs_checked} .py/.pyx pair(s); "
+            f"{len(all_msgs)} mismatch(es) found."
+        )
+        return 1
+
+    print(
+        f"✓ .py ↔ .pyx parity check passed "
+        f"({pairs_checked} pair(s), {len(pyx_files)} .pyx total)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary — v1.2.9 Phase 7/7 (sprint closer)

Closes the v1.2.9 Cython sprint with the infrastructure that prevents the class of bug we lived through at v1.2.85: a security fix that shipped in \`parameters.py\` but not in \`parameters.pyx\`, so compiled-mode users were silently exposed.

Going forward every PR runs the test suite **in both modes** and a structural parity script blocks merges on public-API drift.

## Added

### \`.github/workflows/ci.yml\` (3 jobs)

| Job | Purpose |
|---|---|
| \`parity\` | Runs \`scripts/check_py_pyx_parity.py\` as a gate before tests |
| \`test-pure-python\` | Installs without Cython, verifies no \`.so\` present, runs \`pytest\` |
| \`test-compiled\` | Installs Cython, builds extensions, verifies critical \`.so\` artefacts exist, runs \`pytest\` |

### \`scripts/check_py_pyx_parity.py\`

Structural diff between \`.py\` and \`.pyx\` siblings:
- Public top-level functions match
- Public top-level classes match
- Per shared class, public method set matches
- \`_server_fast.pyx\` whitelisted (no Python equivalent by design)

Cannot detect logic divergence — that's the test suite's job — but catches API drift, which is what enabled v1.2.85 in the first place.

## Local result

\`\`\`
$ python scripts/check_py_pyx_parity.py
✓ .py ↔ .pyx parity check passed (26 pair(s), 27 .pyx total)

$ pytest tests/
367 passed
\`\`\`

## Sprint v1.2.9 — final numbers (vs v1.2.83 baseline, compiled mode)

| | v1.2.83 | v1.2.992 (close) | Δ |
|---|---:|---:|---:|
| FULL HANDLER median | 1.05 µs | **0.94 µs** | **−10.5%** |
| \`process_parameters\` — path+query | 0.57 µs | 0.58 µs | +1.8% |
| \`process_parameters\` — body POST | — | 0.77 µs | — |
| \`process_parameters\` — no params | 0.16 µs | 0.16 µs | unchanged |
| \`parse_bearer_header\` per call | 0.268 µs | **0.166 µs** | **1.61×** |
| Tests | 366/367 | **367/367** | clean |
| Compiled modules | 7 | **27** | +20 |
| \`parameters.pyx\` LOC | 460 monolith | **175 orchestrator** | −62% |

The conservative target of ≤ 0.95 µs FULL HANDLER median is met.  More importantly, the SRP refactor (eight atomic extractors in their own \`.pyx\`/\`.pxd\` pairs) is now visible in production compiled mode, not just in pure-Python fallback.

## Sprint complete

7/7 phases shipped. Ready for v1.3.0 cut (sprint culmination) at your call.