### PR TITLE
fix(v1.2.993): DI scope divergence in compiled mode + query list DoS guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.2.993] — 2026-05-22
+
+**Pre-v1.3.0 audit fixes: silent DI scope divergence in compiled mode + query
+list DoS guard.**
+
+A pre-v1.3.0 punch-list audit surfaced two real bugs that neither the test
+suite nor the Phase 7 parity script could catch on their own.  This patch
+release fixes both before tagging v1.3.0.
+
+### Fixed
+
+#### 1. `compiler.pyx` — `has_callable_deps` missed the DI scope check
+
+`processing/compiler.pyx:115` flagged an endpoint as needing a per-request
+`dependency_cache` ONLY when it had a `Depends(callable)` parameter — it
+never checked whether class-typed dependencies were singleton-scoped vs
+request-/transient-scoped.  `processing/compiler.py` did check.
+
+Concretely, code like this:
+
+```python
+@injectable(scope=SCOPE_REQUEST)
+class Counter: ...
+
+@app.get("/x")
+def handler(c: Counter): ...
+```
+
+would correctly create a fresh `Counter` per request under the pure-Python
+fallback, but silently behave like a singleton when shipping the
+Cython-compiled `.so` — because `has_callable_deps == False` meant the
+orchestrator skipped allocating `dependency_cache`, so the class factory
+fell through to the singleton path.
+
+This is the same shape of bug as the v1.2.85 incident (security fix landed
+in `.py` only).  The Phase 7 parity script cannot detect this class of
+drift because the public API of both `CompiledEndpoint` is identical —
+only the computed value differs.
+
+**Fix**: `compiler.pyx:115` now mirrors `compiler.py:98–102` exactly,
+including the `_scopes.get(annotation, SCOPE_SINGLETON) != SCOPE_SINGLETON`
+clause for `KIND_DEP_CLASS` params.  Added
+`tests/test_dependency_injection.py::test_request_scoped_class_di_creates_new_instance_per_request`
+which fires three requests and asserts three distinct counter ids — fails
+loudly if the divergence is ever reintroduced.
+
+#### 2. `query_list` — unbounded CSV expansion was a DoS surface
+
+`_extractors/query_list.py:27` (and the `.pyx` sibling) did
+`values.extend(v.split(","))` with no cap on the final list size.  A
+single request like `GET /items?ids=1,2,3,...,1000000` would happily
+allocate a million-element Python list before hitting type conversion.
+
+**Fix**: added `MAX_QUERY_LIST_SIZE = 1000` (importable from both `.py`
+and `.pyx`).  When the extractor's running list exceeds it, returns
+HTTP 422 with `"Query parameter '<name>' exceeds maximum list size (1000
+items)"` and never grows further.  Added
+`tests/test_query_params.py::test_query_list_under_cap_succeeds` and
+`test_query_list_over_cap_rejected_with_422` — both exercise the limit
+via real HTTP requests through the test client.
+
+### Result
+
+| | Before | After |
+|---|---:|---:|
+| Tests passing | 367/367 | **370/370** |
+| Compiled-mode bugs found pre-v1.3.0 | 1 | **0** known |
+| Parity script | ✓ | ✓ |
+
+Both fixes ship in `.py` and `.pyx` simultaneously.  Compiled mode now
+correctly allocates `dependency_cache` for non-singleton class DI, and
+both modes reject query lists over 1000 items.
+
+---
+
 ## [1.2.992] — 2026-05-22
 
 **v1.2.9 Cython sprint — Phase 7/7 (CLOSER): CI matrix + `.py` ↔ `.pyx` parity check.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.992"
+version = "1.2.993"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"

--- a/tachyon_api/processing/_extractors/query_list.py
+++ b/tachyon_api/processing/_extractors/query_list.py
@@ -4,8 +4,13 @@
 from starlette.responses import JSONResponse
 
 from ..compiler import ParamDescriptor
+from ...responses import validation_error_response
 from ...utils import TypeConverter
 from ._missing import missing
+
+# DoS guard — caps the final list size after CSV expansion. v1.3.0 audit:
+# ?ids=1,2,...,1000000 would otherwise allocate a million-element list.
+MAX_QUERY_LIST_SIZE = 1000
 
 
 class QueryListExtractor:
@@ -27,6 +32,11 @@ class QueryListExtractor:
                 values.extend(v.split(","))
             else:
                 values.append(v)
+            if len(values) > MAX_QUERY_LIST_SIZE:
+                return (None, validation_error_response(
+                    f"Query parameter '{name}' exceeds maximum list size "
+                    f"({MAX_QUERY_LIST_SIZE} items)"
+                ))
 
         if not values:
             return missing(descriptor, "query parameter", name)

--- a/tachyon_api/processing/_extractors/query_list.pyx
+++ b/tachyon_api/processing/_extractors/query_list.pyx
@@ -6,8 +6,14 @@ Supports both repeated keys (?id=1&id=2) and CSV form (?id=1,2,3).
 
 from starlette.responses import JSONResponse
 
+from ...responses import validation_error_response
 from ...utils import TypeConverter
 from ._missing import missing
+
+# DoS guard — caps the final list size after CSV expansion. v1.3.0 audit:
+# ?ids=1,2,...,1000000 would otherwise allocate a million-element list.
+# Plain Python int so it's importable from both .py and .pyx.
+MAX_QUERY_LIST_SIZE = 1000
 
 
 cdef class QueryListExtractor:
@@ -27,6 +33,11 @@ cdef class QueryListExtractor:
                 values.extend((<str>v).split(","))
             else:
                 values.append(v)
+            if len(values) > MAX_QUERY_LIST_SIZE:
+                return (None, validation_error_response(
+                    f"Query parameter '{name}' exceeds maximum list size "
+                    f"({MAX_QUERY_LIST_SIZE} items)"
+                ))
 
         if not values:
             return missing(descriptor, "query parameter", name)

--- a/tachyon_api/processing/compiler.pyx
+++ b/tachyon_api/processing/compiler.pyx
@@ -14,7 +14,7 @@ import msgspec
 from ..params import Body, Query, Path, Header, Cookie, Form, File
 from ..models import Struct
 from ..background import BackgroundTasks
-from ..di import Depends, _registry
+from ..di import Depends, _registry, _scopes, SCOPE_SINGLETON
 from ..utils import TypeUtils
 
 # Integer kind constants — same values as compiler.py (pure Python fallback)
@@ -112,7 +112,20 @@ cdef class CompiledEndpoint:
         self.params           = params
         self.has_params       = bool(params)
         self.param_count      = len(params)
-        self.has_callable_deps = any((<ParamDescriptor>p).kind == KIND_DEP_CALLABLE for p in params)
+        # Allocate dependency_cache at request time iff any param needs it:
+        #   • KIND_DEP_CALLABLE (Depends(callable)) — always per-request
+        #   • KIND_DEP_CLASS with non-singleton scope — request- or transient-scoped
+        # MUST mirror compiler.py exactly — v1.2.85 / pre-v1.3.0 audit incident:
+        # missing the scope check here silently breaks non-singleton class DI in
+        # compiled mode while pure-Python users are unaffected.
+        self.has_callable_deps = any(
+            (<ParamDescriptor>p).kind == KIND_DEP_CALLABLE
+            or (
+                (<ParamDescriptor>p).kind == KIND_DEP_CLASS
+                and _scopes.get((<ParamDescriptor>p).annotation, SCOPE_SINGLETON) != SCOPE_SINGLETON
+            )
+            for p in params
+        )
         self.has_path_params  = any((<ParamDescriptor>p).kind in (KIND_PATH, KIND_PATH_IMPLICIT) for p in params)
 
 

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -38,6 +38,48 @@ async def test_implicit_dependency_injection():
     assert response.json()["source"] == "mock_db"
 
 
+@pytest.mark.asyncio
+async def test_request_scoped_class_di_creates_new_instance_per_request():
+    """v1.2.993 regression guard — exercises the compiler.pyx scope-check fix.
+
+    Before the fix, `has_callable_deps` on the compiled CompiledEndpoint was
+    True only for `Depends(callable)`, never for non-singleton class DI.
+    Without `has_callable_deps == True` the orchestrator skips allocating
+    `dependency_cache`, which silently makes request-scoped classes behave
+    like singletons in compiled mode (while pure-Python users were fine).
+    This test reaches into the resolver enough to fail loudly if that
+    divergence is reintroduced.
+    """
+    from tachyon_api.di import injectable, SCOPE_REQUEST
+
+    @injectable(scope=SCOPE_REQUEST)
+    class RequestScopedCounter:
+        construction_count = 0
+
+        def __init__(self):
+            RequestScopedCounter.construction_count += 1
+            self.id = RequestScopedCounter.construction_count
+
+    app = Tachyon()
+
+    @app.get("/scoped")
+    def hit(c: RequestScopedCounter):
+        return {"id": c.id}
+
+    async with create_client(app) as client:
+        r1 = await client.get("/scoped")
+        r2 = await client.get("/scoped")
+        r3 = await client.get("/scoped")
+
+    # Request-scoped MUST construct a fresh instance per request.  Singleton
+    # would return the same id for all three.
+    ids = {r1.json()["id"], r2.json()["id"], r3.json()["id"]}
+    assert len(ids) == 3, (
+        f"request-scoped DI behaved like singleton — ids={ids}. "
+        "Likely the compiler.pyx scope check has regressed (see v1.2.993)."
+    )
+
+
 def test_circular_dependency_raises_type_error():
     from tachyon_api import Tachyon
     from tachyon_api.di import injectable

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -1,7 +1,10 @@
+from typing import List
+
 import pytest
 from tachyon_api import Tachyon
 from tests.helpers import create_client
 from tachyon_api.params import Query
+from tachyon_api.processing._extractors.query_list import MAX_QUERY_LIST_SIZE
 
 
 @pytest.mark.asyncio
@@ -63,3 +66,38 @@ async def test_query_params_error_cases(url, expected_detail_part):
     # The framework now uses 422 for parameter validation errors
     assert response.status_code == 422
     assert expected_detail_part in response.text
+
+
+@pytest.mark.asyncio
+async def test_query_list_under_cap_succeeds():
+    """List query params up to MAX_QUERY_LIST_SIZE items are accepted."""
+    app = Tachyon()
+
+    @app.get("/bulk")
+    def bulk(ids: List[int] = Query(...)):
+        return {"count": len(ids)}
+
+    payload = ",".join(str(i) for i in range(MAX_QUERY_LIST_SIZE - 5))
+    async with create_client(app) as client:
+        response = await client.get(f"/bulk?ids={payload}")
+
+    assert response.status_code == 200
+    assert response.json() == {"count": MAX_QUERY_LIST_SIZE - 5}
+
+
+@pytest.mark.asyncio
+async def test_query_list_over_cap_rejected_with_422():
+    """v1.2.993 DoS guard — list query params over MAX_QUERY_LIST_SIZE are rejected."""
+    app = Tachyon()
+
+    @app.get("/bulk")
+    def bulk(ids: List[int] = Query(...)):
+        return {"count": len(ids)}
+
+    payload = ",".join(str(i) for i in range(MAX_QUERY_LIST_SIZE + 100))
+    async with create_client(app) as client:
+        response = await client.get(f"/bulk?ids={payload}")
+
+    assert response.status_code == 422
+    assert "exceeds maximum list size" in response.text
+    assert str(MAX_QUERY_LIST_SIZE) in response.text


### PR DESCRIPTION
## Summary

Pre-v1.3.0 audit surfaced **two real bugs** that neither the test suite nor the Phase 7 parity script could catch on their own.

## Bug 1: \`compiler.pyx\` — \`has_callable_deps\` missed the DI scope check

\`processing/compiler.pyx:115\` flagged an endpoint as needing per-request \`dependency_cache\` ONLY for \`Depends(callable)\`. It never checked whether class-typed deps were singleton vs request-/transient-scoped. \`processing/compiler.py\` did check.

**Effect**: code like

\`\`\`python
@injectable(scope=SCOPE_REQUEST)
class Counter: ...
\`\`\`

built a fresh instance per request under **pure-Python fallback**, but silently **behaved like a singleton when shipping the compiled \`.so\`**. Same shape as v1.2.85 (security fix landed in \`.py\` only). The Phase 7 parity script cannot detect this class of drift because the public API of both \`CompiledEndpoint\` is identical — only the computed value differs.

### Fix
\`compiler.pyx:115\` now mirrors \`compiler.py:98–102\` exactly, including the \`_scopes.get(annotation, SCOPE_SINGLETON) != SCOPE_SINGLETON\` clause for \`KIND_DEP_CLASS\` params.

## Bug 2: \`query_list\` — unbounded CSV expansion was a DoS surface

\`_extractors/query_list.py:27\` (and the \`.pyx\` sibling) did \`values.extend(v.split(\",\"))\` with no cap. \`GET /items?ids=1,2,...,1000000\` would allocate a million-element Python list before any type conversion.

### Fix
\`MAX_QUERY_LIST_SIZE = 1000\` (importable from both \`.py\` and \`.pyx\`). When the extractor's running list exceeds it, returns HTTP 422 with \`\"Query parameter '<name>' exceeds maximum list size (1000 items)\"\`.

## Tests added

| Test | Catches |
|---|---|
| \`test_request_scoped_class_di_creates_new_instance_per_request\` | Bug 1 — 3 requests must produce 3 distinct ids (would fail with 1-id-everywhere if the .pyx divergence regresses) |
| \`test_query_list_under_cap_succeeds\` | Cap allows lists at MAX_QUERY_LIST_SIZE - 5 items |
| \`test_query_list_over_cap_rejected_with_422\` | Bug 2 — overflow returns 422 |

## Result

| | Before | After |
|---|---:|---:|
| Tests passing | 367/367 | **370/370** |
| Known compiled-mode bugs | 1 | **0** |
| Parity script | ✓ | ✓ |

Both fixes ship in \`.py\` and \`.pyx\` simultaneously.

## Pre-v1.3.0 status

After this merge, dev branch is clean of all P1 audit findings. Remaining audit items (CI Python matrix, lint gate, bearer edge tests, etc.) are P2/P3 and can land in v1.3.x.