### PR TITLE
chore: ignore Cython .c artefacts from tachyon_api/ root + security/, plus coverage.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,10 +216,13 @@ HOTFIXES.md
 # Cython build artifacts (generated files — not committed)
 *.so
 *.pyd
+tachyon_api/*.c
 tachyon_api/processing/*.c
 tachyon_api/processing/_extractors/*.c
 tachyon_api/processing/dependencies/*.c
 tachyon_api/app/*.c
 tachyon_api/responses/*.c
 tachyon_api/routing/*.c
+tachyon_api/security/*.c
+coverage.json
 build/


### PR DESCRIPTION
Tiny housekeeping. After v1.2.99 (security/_bearer_parser.pyx) and the original _server_fast.pyx at the package root, two more directories generate .c files at compile time but were not covered by the existing .gitignore patterns. Also ignore coverage.json (sibling of the already-ignored coverage.xml).

Effect: `git status` stays clean after `python setup.py build_ext --inplace` and `pytest --cov`. No runtime impact.