### PR TITLE
docs: remove stale build_ext instructions from getting-started and migration

### DIFF
--- a/docs/01-getting-started.md
+++ b/docs/01-getting-started.md
@@ -24,17 +24,17 @@ Tachyon instala automáticamente:
 - `msgspec` - Validación y serialización ultra-rápida
 - `orjson` - JSON encoding/decoding rápido
 
-### Optional: High-Performance Builds
+### Precompiled extensions
 
-For additional speed on the request hot path (radix trie + parameter processing compiled to C):
+`pip install tachyon-api` already ships **27 precompiled Cython extensions** for Linux (x86_64, aarch64), macOS (arm64), and Windows (x86_64) on CPython 3.10–3.13. No extra step required — the compiled hot path is active by default.
+
+On platforms without a published wheel (e.g. macOS Intel), `pip` builds from source. That path requires a C compiler and Cython:
 
 ```bash
-pip install tachyon-api[fast]          # installs cython
-python setup.py build_ext --inplace    # compile extensions
+pip install tachyon-api[fast]   # pulls in Cython for source builds
 ```
 
-Falls back to pure Python automatically when `.so` is not present — no code changes needed.
-The Cython extensions give ~11% improvement on the Python processing layer.
+If compilation fails for any reason, Tachyon falls back to pure Python automatically — no code changes needed. The Cython extensions add ~14% throughput on top of the already-fast pure-Python baseline.
 
 For production servers, also use:
 

--- a/docs/14-migration-fastapi.md
+++ b/docs/14-migration-fastapi.md
@@ -24,9 +24,10 @@ pip uninstall fastapi pydantic
 # Install Tachyon
 pip install tachyon-api
 
-# Optional: Cython extensions for ~11% extra speed
+# Cython extensions ship precompiled — no extra step on supported platforms
+# (Linux x86_64/aarch64, macOS arm64, Windows x86_64, CPython 3.10-3.13)
+# On other platforms, add [fast] to build from source:
 # pip install tachyon-api[fast]
-# python setup.py build_ext --inplace
 ```
 
 ---
@@ -414,8 +415,7 @@ Typical results after migrating from FastAPI:
 
 For maximum performance in production:
 ```bash
-pip install tachyon-api[fast]                          # Cython extensions
-python setup.py build_ext --inplace                    # compile
+pip install tachyon-api                                # precompiled extensions included
 uvicorn app:app --loop uvloop --http httptools          # fast server config
 ```
 


### PR DESCRIPTION
## Summary

- Removes `python setup.py build_ext --inplace` from the two docs that still referenced it after PR #65 shipped precompiled wheels.
- `[fast]` extra repositioned as the source-build path (macOS Intel, Alpine, etc.), not the standard user install.

## Files changed

- `docs/01-getting-started.md` — "Optional: High-Performance Builds" block replaced with accurate description of precompiled wheel delivery.
- `docs/14-migration-fastapi.md` — stale `build_ext` lines removed from both the install snippet and the "maximum performance" block.

## Test plan
- [ ] Read-through of both docs renders correctly on GitHub
- [ ] No other docs reference `build_ext` (confirmed by audit — these were the only two)