### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [1.3.0] — 2026-05-27
 
 **Precompiled wheels: `pip install tachyon-api` now ships compiled Cython
 extensions out of the box on the supported matrix.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tachyon-api"
-version = "1.2.993"
+version = "1.3.0"
 description = "A lightweight, FastAPI-inspired web framework"
 authors = ["Juan Manuel Panozzo Zénere <jm.panozzozenere@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## v1.3.0 — Precompiled wheels

Bumps version `1.2.993` → `1.3.0` and closes the `[Unreleased]` CHANGELOG entry.

### What's in this release

`pip install tachyon-api` now ships **20 precompiled wheels** with all 27 Cython extensions compiled for:

| Platform | Architectures | Python |
|---|---|---|
| Linux | x86_64, aarch64 | 3.10 · 3.11 · 3.12 · 3.13 |
| macOS | arm64 | 3.10 · 3.11 · 3.12 · 3.13 |
| Windows | x86_64 | 3.10 · 3.11 · 3.12 · 3.13 |

No manual `build_ext` step. No Cython required on the user's machine. Pure-Python runtime fallback is preserved for unsupported platforms.

### After merging

1. Merge this PR into `dev`
2. Open PR `dev → main`, merge
3. Tag `v1.3.0` on `main` → triggers `build-wheels.yml` (20 wheels + sdist as artifacts)
4. Download `dist-all` artifact + `twine upload dist/*`