### PR TITLE
fix(tests): replace deprecated get_event_loop() with asyncio.run()

### DIFF
--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -987,7 +987,7 @@ def test_cache_async_backend_set_failure_logged(caplog):
 
     import asyncio
     with caplog.at_level(logging.WARNING):
-        result = asyncio.get_event_loop().run_until_complete(afn())
+        result = asyncio.run(afn())
     assert result == 42  # still returns despite set failure
 
 


### PR DESCRIPTION
## Problem

`test_cache_async_backend_set_failure_logged` was calling `asyncio.get_event_loop().run_until_complete()`, which:
- Passes on Python 3.10.0 (local) with a `DeprecationWarning`
- Raises `RuntimeError: There is no current event loop in thread 'MainThread'` on Python 3.10.20+ (CI runner)

This caused the CI on the v1.3.0 main merge to show 1 failed / 369 passed.

## Fix

Replace with `asyncio.run()` which always creates a fresh event loop.

## Note

Not a regression introduced by v1.3.0 changes — this test was always broken on newer 3.10.x, just masked locally by the older pyenv version.