### PR TITLE
fix(tests): asyncio.run() backport to main

### DIFF
--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -987,7 +987,7 @@ def test_cache_async_backend_set_failure_logged(caplog):
 
     import asyncio
     with caplog.at_level(logging.WARNING):
-        result = asyncio.get_event_loop().run_until_complete(afn())
+        result = asyncio.run(afn())
     assert result == 42  # still returns despite set failure
 
 


### PR DESCRIPTION
Backports the asyncio event loop fix from PR #70 to main. Keeps main's CI green after the v1.3.0 release.